### PR TITLE
Add check and error message for missing @odata.id in validateEntity()

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -79,6 +79,10 @@ def validateEntity(name, val, propType, propCollectionType, soup, refs, autoExpa
     """
     Validates an entity based on its uri given
     """
+    # check for required @odata.id
+    if '@odata.id' not in val:
+        rsvLogger.error("{}: EntityType resource does not contain required @odata.id property".format(name))
+        return False
     # check if the entity is truly what it's supposed to be
     uri = val['@odata.id']
     paramPass = False


### PR DESCRIPTION
validateEntity() is called for items that are an EntityType. It assumed the required @odata.id property was present and would get an exception if it wasn't. Added explicit check that @odata.id is present. And if not issue an appropriate error message.

The error message looks like this:

ERROR - Power.v1_0_0.PowerSupply:Redundancy: EntityType resource does not contain required @odata.id property

Fixes #105 

@jautor - fix for #105 is in this PR.