### PR TITLE
Add check for proper RedfishExtensions alias in $metadata

### DIFF
--- a/traverseService.py
+++ b/traverseService.py
@@ -364,6 +364,21 @@ def getSchemaDetailsLocal(SchemaType, SchemaURI):
     return False, None, None
 
 
+def check_redfish_extensions_alias(name, item):
+    """
+    Check that edmx:Include for Namespace RedfishExtensions has the expected 'Redfish' Alias attribute
+    :param name: the name of the resource
+    :param item: the edmx:Include item for RedfishExtensions
+    :return:
+    """
+    alias = item.get('Alias')
+    if alias is None or alias != 'Redfish':
+        msg = ("In the resource {}, the {} namespace must have an alias of 'Redfish'. The alias is {}. " +
+               "This may cause properties of the form [PropertyName]@Redfish.TermName to be unrecognized.")
+        traverseLogger.error(msg.format(name, item.get('Namespace'),
+                             'missing' if alias is None else "'" + str(alias) + "'"))
+
+
 def getReferenceDetails(soup, metadata_dict=None, name='xml'):
     """
     Create a reference dictionary from a soup file
@@ -387,6 +402,9 @@ def getReferenceDetails(soup, metadata_dict=None, name='xml'):
                 refDict[item['Alias']] = (item['Namespace'], ref['Uri'])
             else:
                 refDict[item['Namespace']] = (item['Namespace'], ref['Uri'])
+            # Check for proper Alias for RedfishExtensions
+            if name == '$metadata' and item.get('Namespace').startswith('RedfishExtensions.'):
+                check_redfish_extensions_alias(name, item)
 
     cntref = len(refDict)
     if metadata_dict is not None:


### PR DESCRIPTION
Added check that the RedfishExtensions namespace in $metadata has the expected Alias value of 'Redfish'. If not, it generates an error message like this:

"ERROR - In the resource $metadata, the RedfishExtensions.v1_0_0 namespace must have an alias of 'Redfish'. The alias is 'RedfishExtensions'. This may cause properties of the form [PropertyName]@Redfish.TermName to be unrecognized."

Initially, I tried to make it so that this error is only generated once. Unfortunately, I ran into issues getting that to work based on where the getReferenceDetails() function is called from. So, for now, the message will appear once in each resource section of the HTML report. I'll revisit this in future. But I wanted to go ahead and push this version since it is working and I think will be helpful.

![screen shot 2017-10-18 at 1 26 40 pm](https://user-images.githubusercontent.com/3341721/31736799-59b7c940-b40b-11e7-9a92-65b7df1d6504.png)

Fixes #106 