### PR TITLE
Removed accidental repeat from move-config PR, fixed $metadata bug

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -844,6 +844,7 @@ def main(argv=None):
     # Start main
     status_code = 1
     jsonData = None
+    
     pmode, ppath = cdict.get('payloadmode'), cdict.get('payloadfilepath')
     if pmode not in ['Tree', 'Single', 'SingleFile', 'TreeFile', 'Default']:
         pmode = 'Default'
@@ -863,23 +864,6 @@ def main(argv=None):
     else:
         success, counts, results, xlinks, topobj = validateURITree('/redfish/v1', 'ServiceRoot', expectedJson=jsonData)
 
-    if rst.config.get('payloadmode') not in ['Tree', 'Single', 'SingleFile', 'TreeFile', 'Default']:
-        rst.config['payloadmode'] = 'Default'
-        rsvLogger.error('PayloadMode or path invalid, using Default behavior')
-    if 'File' in rst.config.get('payloadmode'):
-        if rst.config.get('payloadfilepath') is not None and os.path.isfile(rst.config.get('payloadfilepath')):
-            with open(rst.config.get('payloadfilepath')) as f:
-                jsonData = json.load(f)
-                f.close()
-        else:
-            rsvLogger.error('File not found {}'.format(rst.config.get('payloadfilepath')))
-            return 1
-    if 'Single' in rst.config.get('payloadmode'):
-        success, counts, results, xlinks, topobj = validateSingleURI(rst.config.get('payloadfilepath'), 'Target', expectedJson=jsonData)
-    elif 'Tree' in rst.config.get('payloadmode'):
-        success, counts, results, xlinks, topobj = validateURITree(rst.config.get('payloadfilepath'), 'Target', expectedJson=jsonData)
-    else:
-        success, counts, results, xlinks, topobj = validateURITree('/redfish/v1', 'ServiceRoot', expectedJson=jsonData)
     finalCounts = Counter()
     nowTick = datetime.now()
     rsvLogger.info('Elapsed time: {}'.format(str(nowTick-startTick).rsplit('.', 1)[0]))  # Printout FORMAT

--- a/traverseService.py
+++ b/traverseService.py
@@ -260,7 +260,7 @@ def getSchemaDetails(SchemaType, SchemaURI):
 
     LocalOnly, SchemaLocation, ServiceOnly = config['localonlymode'], config['metadatafilepath'], config['servicemode']
 
-    if SchemaURI is not None and not LocalOnly:
+    if SchemaURI is not None and not LocalOnly or '/redfish/v1/$metadata' in SchemaURI:
         # Get our expected Schema file here
         # if success, generate Soup, then check for frags to parse
         #   start by parsing references, then check for the refLink


### PR DESCRIPTION
Fixes accidental introduction of a second code loop in move-config

Fix #99, given that /redfish/v1/$metadata accurately resolves as a valid XML file