### PR TITLE
Validate Redfish.DynamicPropertyPatterns for Bios Attributes

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -186,7 +186,7 @@ def validateComplex(name, val, propTypeObj, payloadType):
         complexMessages.update(aMsgs)
         complexCounts.update(aCounts)
 
-    # validate the Redfish.DynamicPropertyPatterns if specified
+    # validate the Redfish.DynamicPropertyPatterns if present
     if propTypeObj.propPattern is not None and len(propTypeObj.propPattern) > 0:
         patternMessages, patternCounts = validateDynamicPropertyPatterns(name, val, propTypeObj, payloadType)
         complexMessages.update(patternMessages)

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -912,7 +912,7 @@ def main(argv=None):
                 if typename not in linklimitdict:
                     linklimitdict[typename] = int(count)
                 else:
-                    traverseLogger.error('Limit already exists for {}'.format(typename))
+                    rsvLogger.error('Limit already exists for {}'.format(typename))
         cdict['linklimit'] = linklimitdict
 
         rst.setConfig({key: cdict[key] for key in cdict.keys() if key in rst.configset.keys()})

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -186,6 +186,7 @@ def validateComplex(name, val, propTypeObj, payloadType):
         complexMessages.update(aMsgs)
         complexCounts.update(aCounts)
 
+    # validate the Redfish.DynamicPropertyPatterns if specified
     if propTypeObj.propPattern is not None and len(propTypeObj.propPattern) > 0:
         patternMessages, patternCounts = validateDynamicPropertyPatterns(name, val, propTypeObj, payloadType)
         complexMessages.update(patternMessages)
@@ -195,6 +196,14 @@ def validateComplex(name, val, propTypeObj, payloadType):
 
 
 def validateDynamicPropertyType(name, key, value, prop_type):
+    """
+    Check the type of the property value
+    :param name: the name of the dictionary of properties being validated
+    :param key: the key of the individual property being validated
+    :param value: the value of the individual property being validated
+    :param prop_type: the expected type of the value
+    :return: True if the type check passes, False otherwise
+    """
     type_pass = True
     if prop_type == 'Edm.Primitive' or prop_type == 'Edm.PrimitiveType':
         type_pass = isinstance(value, (int, float, str, bool))
@@ -219,6 +228,14 @@ def validateDynamicPropertyType(name, key, value, prop_type):
 
 
 def validateDynamicPropertyPatterns(name, val, propTypeObj, payloadType):
+    """
+    Checks the value type and key pattern of the properties specified via Redfish.DynamicPropertyPatterns annotation
+    :param name: the name of the dictionary of properties being validated
+    :param val: the dictionary of properties being validated
+    :param propTypeObj: the PropType instance
+    :param payloadType: the type of the payload being validated
+    :return: the messages and counts of the validation results
+    """
     messages = OrderedDict()
     counts = Counter()
     rsvLogger.debug('validateDynamicPropertyPatterns: name = {}, type(val) = {}, pattern = {}, payloadType = {}'

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -195,20 +195,26 @@ def validateComplex(name, val, propTypeObj, payloadType):
 
 
 def validateDynamicPropertyType(name, key, value, prop_type):
-    if prop_type == 'Edm.Primitive':
-        primitive = (int, float, str, bool)
-        type_pass = isinstance(value, primitive)
-        if not type_pass:
-            rsvLogger.error('{} key "{}" with value "{}" is not of type "{}"'.format(name, key, value, prop_type))
+    type_pass = True
+    if prop_type == 'Edm.Primitive' or prop_type == 'Edm.PrimitiveType':
+        type_pass = isinstance(value, (int, float, str, bool))
     elif prop_type == 'Edm.String':
         type_pass = isinstance(value, str)
-        if not type_pass:
-            rsvLogger.error('{} key "{}" with value "{}" is not of type "{}"'.format(name, key, value, prop_type))
-    # TODO: handle other types
+    elif prop_type == 'Edm.Boolean':
+        type_pass = isinstance(value, bool)
+    elif prop_type == 'Edm.DateTimeOffset':
+        type_pass = validateDatetime(key, value)
+    elif prop_type == 'Edm.Int' or prop_type == 'Edm.Int16' or prop_type == 'Edm.Int32' or prop_type == 'Edm.Int64':
+        type_pass = isinstance(value, int)
+    elif prop_type == 'Edm.Decimal' or prop_type == 'Edm.Double':
+        type_pass = isinstance(value, (int, float))
+    elif prop_type == 'Edm.Guid':
+        type_pass = validateGuid(key, value)
     else:
-        type_pass = True
-        rsvLogger.warning('{} Do not know how to validate type "{}" for the value of key "{}"'
-                          .format(name, prop_type, key))
+        rsvLogger.debug('{}: Do not know how to validate type "{}" for the value of key "{}"'
+                        .format(name, prop_type, key))
+    if not type_pass:
+        rsvLogger.error('{} key "{}" with value "{}" is not of type "{}"'.format(name, key, value, prop_type))
     return type_pass
 
 

--- a/traverseService.py
+++ b/traverseService.py
@@ -964,9 +964,7 @@ def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=N
             item = getType(key).split(':')[-1]
             if propDict['realtype'] == 'complex':
                 if jsonData.get(item) is not None:
-                    cType = None
-                    if propDict.get('isCollection') is not None:
-                        cType = getType(propDict.get('isCollection'))
+                    cType = propDict.get('isCollection')
                     if cType is not None:
                         cTypeName = getType(cType)
                         for cnt, listItem in enumerate(jsonData[item]):

--- a/traverseService.py
+++ b/traverseService.py
@@ -613,11 +613,12 @@ class PropType:
         self.isNav = False
         self.propList = []
         self.parent = None
+        self.propPattern = None
 
         propertyList = self.propList
         success, baseSoup, baseRefs, baseType = True, self.soup, self.refs, self.fulltype
         try:
-            self.additional, newList = getTypeDetails(
+            self.additional, newList, self.propPattern = getTypeDetails(
                 baseSoup, baseRefs, baseType, self.tagType, topVersion)
             propertyList.extend(newList)
             success, baseSoup, baseRefs, baseType = getParentType(
@@ -646,6 +647,7 @@ def getTypeDetails(soup, refs, SchemaAlias, tagType, topVersion=None):
     Gets list of surface level properties for a given SchemaType,
     """
     PropertyList = list()
+    PropertyPattern = None
     additional = False
 
     SchemaNamespace, SchemaType = getNamespace(
@@ -660,7 +662,7 @@ def getTypeDetails(soup, refs, SchemaAlias, tagType, topVersion=None):
     if innerschema is None:
         traverseLogger.error("Got XML, but expected schema doesn't exist...? {}, {}\n... we will be unable to generate properties".format(
                              SchemaNamespace, SchemaType))
-        return False, PropertyList
+        return False, PropertyList, PropertyPattern
 
     element = innerschema.find(tagType, attrs={'Name': SchemaType}, recursive=False)
     traverseLogger.debug("___")
@@ -682,6 +684,21 @@ def getTypeDetails(soup, refs, SchemaAlias, tagType, topVersion=None):
     else:
         additional = False
     if additionalElementOther is not None:
+        # create PropertyPattern dict containing pattern and type for DynamicPropertyPatterns validation
+        traverseLogger.debug('getTypeDetails: Redfish.DynamicPropertyPatterns found, element = {}, SchemaAlias = {}'
+                             .format(element, SchemaAlias))
+        pattern_elem = additionalElementOther.find("PropertyValue", Property="Pattern")
+        pattern = prop_type = None
+        if pattern_elem is not None:
+            pattern = pattern_elem.get("String")
+        type_elem = additionalElementOther.find("PropertyValue", Property="Type")
+        if type_elem is not None:
+            prop_type = type_elem.get("String")
+        traverseLogger.debug('getTypeDetails: pattern = {}, type = {}'.format(pattern, prop_type))
+        if pattern is not None and prop_type is not None:
+            PropertyPattern = dict()
+            PropertyPattern['Pattern'] = pattern
+            PropertyPattern['Type'] = prop_type
         additional = True
 
     for innerelement in usableProperties:
@@ -695,7 +712,7 @@ def getTypeDetails(soup, refs, SchemaAlias, tagType, topVersion=None):
             PropertyList.append(
                 PropItem(soup, refs, newPropOwner, newProp, tagType=tagType, topVersion=topVersion))
 
-    return additional, PropertyList
+    return additional, PropertyList, PropertyPattern
 
 
 def getPropertyDetails(soup, refs, propOwner, propChild, tagType='EntityType', topVersion=None):

--- a/traverseService.py
+++ b/traverseService.py
@@ -964,7 +964,9 @@ def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=N
             item = getType(key).split(':')[-1]
             if propDict['realtype'] == 'complex':
                 if jsonData.get(item) is not None:
-                    cType = getType(propDict.get('isCollection'))
+                    cType = None
+                    if propDict.get('isCollection') is not None:
+                        cType = getType(propDict.get('isCollection'))
                     if cType is not None:
                         cTypeName = getType(cType)
                         for cnt, listItem in enumerate(jsonData[item]):


### PR DESCRIPTION
Addresses the first item mentioned in #77.

- For properties with the Redfish.DynamicPropertyPatterns annotation, validates that the keys match the specified pattern and that the values are of the specified type.
- Also fixes a bug in the tool where a NoneType is dereferenced.
- And corrects an issue where the wrong logger instance is used to log an error.

There are some additional issues described in #77 that I'm still working on, so will keep that issue open.

Screenshot showing the beginning of the Bios resource validation report. Note that a couple of errors were introduced in the payload:

![screen shot 2017-11-02 at 12 38 05 pm](https://user-images.githubusercontent.com/3341721/32341305-29ff358c-bfcb-11e7-8dfd-89a3c78c6850.png)

And a screenshot showing the end of the Bios resource validation report. Note the errors for the 2 validation failures:

![screen shot 2017-11-02 at 12 38 40 pm](https://user-images.githubusercontent.com/3341721/32341387-5adc0e3c-bfcb-11e7-87a8-3d1b303640dd.png)
