### PR TITLE
Validate Bios attributes against attribute registry

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -487,7 +487,7 @@ def loadAttributeRegDict(odata_type, json_data):
         rsvLogger.debug('{}: Expected json_data param to be a dict, found {}'.format(fn, type(json_data)))
         return
 
-    # get Id property if present; if missing us e a key of 'default' to store the dictionary
+    # get Id property if present; if missing use a key of 'default' to store the dictionary
     reg_id = json_data.get('Id')
     if reg_id is None:
         reg_id = 'default'

--- a/traverseService.py
+++ b/traverseService.py
@@ -981,6 +981,10 @@ def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=N
         traverseLogger.debug(str(linkList))
     except Exception as ex:
         traverseLogger.exception("Something went wrong")
+    # contents of Registries may be needed to validate other resources (like Bios), so move to front of linkList
+    if 'Registries.Registries' in linkList:
+        linkList.move_to_end('Registries.Registries', last=False)
+        traverseLogger.debug('getAllLinks: Moved Registries.Registries to front of list')
     return linkList
 
 


### PR DESCRIPTION
Validate Bios attributes against attribute registry:
- Ensure Registries are loaded early so the contents will be available for validation of other resources (e.g. Bios)
- Load any attribute registries found into dictionaries that can be retrieved later
- When validating attribute properties in Bios, validate against the type specified in the attribute registry

Fixes #77 

A couple of screenshots to show how validation failures from the attribute registry checks will look:

![screen shot 2017-11-07 at 4 42 47 pm](https://user-images.githubusercontent.com/3341721/32563683-7e230430-c477-11e7-8021-1fc427325ed8.png)

![screen shot 2017-11-07 at 4 43 17 pm](https://user-images.githubusercontent.com/3341721/32563711-8b54e3f8-c477-11e7-8743-aa93a43352e0.png)
