### PR TITLE
Add encoding=utf8 to html file open to fix UnicodeEncodeError

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1079,7 +1079,7 @@ def main(argv=None):
 
     htmlPage = htmlStrTop + htmlStrBodyHeader + htmlStrTotal + htmlStr
 
-    with open(datetime.strftime(startTick, os.path.join(logpath, "ConformanceHtmlLog_%m_%d_%Y_%H%M%S.html")), 'w') as f:
+    with open(datetime.strftime(startTick, os.path.join(logpath, "ConformanceHtmlLog_%m_%d_%Y_%H%M%S.html")), 'w', encoding='utf-8') as f:
         f.write(htmlPage)
 
     fails = 0


### PR DESCRIPTION
Added encoding='utf8' to open() of html report file to fix the reported UnicodeEncodeError.

Fixes #116 