### PR TITLE
Fix Nullable property validation logic

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -487,8 +487,8 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
     isCollection = propCollectionType is not None
     if isCollection and propValue is None:
         # illegal for a collection to be null
-        rsvLogger.error('Value of Collection property {} in {} is null but Collections cannot be null, only their entries'
-                        .format(PropertyName, item))
+        rsvLogger.error('Value of Collection property {} is null but Collections cannot be null, only their entries'
+                        .format(PropertyName))
         propValueList = []
     elif propCollectionType is not None and propNotNull:
         # note: handle collections correctly, this needs a nicer printout

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -510,12 +510,12 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
     # OK!
     for cnt, val in enumerate(propValueList):
         appendStr = (('#' + str(cnt)) if isCollection else '')
-        if propRealType is not None and propExists and propValue is not None:
+        if propRealType is not None and propExists:
             paramPass = propNullablePass = True
             if val is None:
                 if propNullable:
-                    rsvLogger.debug('Property #{} in {} is nullable and is null, so Nullable checking passes'
-                                    .format(cnt, PropertyName))
+                    rsvLogger.debug('Property {}{} is nullable and is null, so Nullable checking passes'
+                                    .format(PropertyName, '#' + str(cnt) if isCollection else ''))
                 else:
                     propNullablePass = False
 
@@ -606,7 +606,8 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
                 rsvLogger.error("%s: Mandatory prop does not exist" % PropertyName)  # Printout FORMAT
                 counts['failMandatoryExist'] += 1
             elif not propNullablePass:
-                rsvLogger.error('Property #{} in {} is null but is not Nullable'.format(cnt, PropertyName))
+                rsvLogger.error('Property {}{} is null but is not Nullable'
+                                .format(PropertyName, '#' + str(cnt) if isCollection else ''))
                 counts['failNullable'] += 1
             rsvLogger.info("\tFAIL")  # Printout FORMAT
 

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -511,10 +511,10 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
             if val is None:
                 if propNullable:
                     paramPass = True
-                    rsvLogger.debug('Property {} is nullable and is null, so type checking passes'
-                                    .format(PropertyName))
+                    rsvLogger.debug('Property #{} in {} is nullable and is null, so type checking passes'
+                                    .format(cnt, PropertyName))
                 else:
-                    rsvLogger.error('Property {} is null but is not Nullable'.format(PropertyName))
+                    rsvLogger.error('Property #{} in {} is null but is not Nullable'.format(cnt, PropertyName))
 
             elif propRealType == 'Edm.Boolean':
                 paramPass = isinstance(val, bool)


### PR DESCRIPTION
Corrected the Nullable property validation logic. Behavior now is:
- If an entry in a collection is null and the collection property is Nullable, validation passes
- If an entry in a collection is null and the collection property is NOT Nullable, validation fails
- If the value of the collection itself is null (rather than an entry in the collection), validation fails
- For primitive (non-collection) properties, the logic is consistent with the first 2 bullets above

Fixes #117 

Here are a couple of screenshots showing the original behavior where the tool incorrectly flagged a null collection value as invalid (even though the property was Nullable):

![screen shot 2017-11-13 at 12 33 55 pm](https://user-images.githubusercontent.com/3341721/32750754-42203e24-c889-11e7-9f4b-c85e4565a157.png)

![screen shot 2017-11-13 at 12 34 21 pm](https://user-images.githubusercontent.com/3341721/32750778-4e827042-c889-11e7-83e3-40d7b5e63cb4.png)

And here is a screenshot showing the same validation after the fix. Validation now passes:

![screen shot 2017-11-13 at 12 38 30 pm](https://user-images.githubusercontent.com/3341721/32750848-8473e532-c889-11e7-95e3-3d0505fef119.png)

Also, if an entry is null and the property is NOT Nullable, an error like this is reported:

```
ERROR - Property #1 in ManagerNetworkProtocol.v1_2_0.NTPProtocol:NTPServers is null but is not Nullable
```

And finally, if the collection itself is null, an error like this is reported:

```
ERROR - Value of Collection property ManagerNetworkProtocol.v1_2_0.NTPProtocol:NTPServers is null but Collections cannot be null, only their entries
```