### PR TITLE
Add support for sampling random members from large collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ CacheFilePath = Path to cache directory
 
 LinkLimit = TypeName:## -- Option to limit the amount of links accepted from collections, default LogEntry:20
 
+Sample = (integer) Number of random members from large collections to validate. The default is to validate all members. All members will be validated if a value of zero or a negative number is specified. If a LinkLimit and Sample apply to a given collection, the LinkLimit takes precedence.
+
 PayloadMode = [Default, Tree, Single, TreeFile, SingleFile] -- Options for the target of validation, allowing to specify a file or specific URI and traversal behavior
 
 PayloadFilePath = Path to URI/File

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -925,13 +925,14 @@ def main(argv=None):
             return 1
         # Send config only with keys supported by program
         linklimitdict = {}
-        for item in cdict.get('linklimit',{}):
-            if re.match('[A-Za-z_]+:[0-9]+', item) is not None:
-                typename, count = tuple(item.split(':')[:2])
-                if typename not in linklimitdict:
-                    linklimitdict[typename] = int(count)
-                else:
-                    rsvLogger.error('Limit already exists for {}'.format(typename))
+        if cdict.get('linklimit') is not None:
+            for item in cdict.get('linklimit'):
+                if re.match('[A-Za-z_]+:[0-9]+', item) is not None:
+                    typename, count = tuple(item.split(':')[:2])
+                    if typename not in linklimitdict:
+                        linklimitdict[typename] = int(count)
+                    else:
+                        rsvLogger.error('Limit already exists for {}'.format(typename))
         cdict['linklimit'] = linklimitdict
 
         rst.setConfig({key: cdict[key] for key in cdict.keys() if key in rst.configset.keys()})

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -840,7 +840,8 @@ argparse2configparser = {
         'suffix': 'schemasuffix', 'schemadir': 'metadatafilepath', 'nossl': '!usessl', 'timeout': 'timeout', 'service': 'servicemode',
         'http_proxy': 'httpproxy', 'localonly': 'localonlymode', 'https_proxy': 'httpsproxy', 'passwd': 'password',
         'ip': 'targetip', 'logdir': 'logpath', 'desc': 'systeminfo', 'authtype': 'authtype',
-        'payload': 'payloadmode+payloadfilepath', 'cache': 'cachemode+cachefilepath', 'token': 'token', 'linklimit': 'linklimit'}
+        'payload': 'payloadmode+payloadfilepath', 'cache': 'cachemode+cachefilepath', 'token': 'token',
+        'linklimit': 'linklimit', 'sample': 'sample'}
 
 validatorconfig = {'payloadmode': 'Default', 'payloadfilepath': None, 'logpath': './logs'}
 
@@ -877,6 +878,7 @@ def main(argv=None):
     argget.add_argument('--payload', type=str, help='mode to validate payloads [Tree, Single, SingleFile, TreeFile] followed by resource/filepath', nargs=2)
     argget.add_argument('--cache', type=str, help='cache mode [Off, Fallback, Prefer] followed by directory', nargs=2)
     argget.add_argument('--linklimit', type=str, help='Limit the amount of links in collections, formatted TypeName:## TypeName:## ..., default LogEntry:20 ', nargs='*')
+    argget.add_argument('--sample', type=int, default=0, help='sample this number of members from large collections for validation; default is to validate all members')
 
     args = argget.parse_args()
 

--- a/config.ini
+++ b/config.ini
@@ -24,6 +24,7 @@ HttpsProxy =
 LocalOnlyMode = False
 ServiceMode = False
 LinkLimit = LogEntry:20
+Sample = 0
 
 [Validator]
 PayloadMode = Default

--- a/traverseService.py
+++ b/traverseService.py
@@ -888,12 +888,12 @@ def getPropertyDetails(soup, refs, propOwner, propChild, tagType='EntityType', t
 
 def enumerate_collection(items, cTypeName, linklimits, sample_size):
     """
-    Generator function to enumerate the the items in a collection, applying the link limit or sample size if applicable.
+    Generator function to enumerate the items in a collection, applying the link limit or sample size if applicable.
     If a link limit is specified for this cTypeName, return the first N items as specified by the limit value.
     If a sample size greater than zero is specified, return a random sample of items specified by the sample_size.
     In both the above cases, if the limit value or sample size is greater than or equal to the number of items in the
     collection, return all the items.
-    If a limit value and sample size are both provided, the limit value takes precedence.
+    If a limit value for this cTypeName and a sample size are both provided, the limit value takes precedence.
     :param items: the collection of items to enumerate
     :param cTypeName: the type name of this collection
     :param linklimits: a dictionary mapping type names to their limit values

--- a/traverseService.py
+++ b/traverseService.py
@@ -998,10 +998,12 @@ def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=N
                         cTypeName = getType(cType)
                         for cnt, listItem in enumerate_collection(jsonData[item], cTypeName, linklimits, sample_size):
                             linkList.update(getAllLinks(
-                                listItem, propDict['typeprops'].propList, refDict, prefix + item + '.', context, sample_size=sample_size))
+                                listItem, propDict['typeprops'].propList, refDict, prefix + item + '.', context,
+                                linklimits=linklimits, sample_size=sample_size))
                     else:
                         linkList.update(getAllLinks(
-                            jsonData[item], propDict['typeprops'].propList, refDict, prefix + item + '.', context, sample_size=sample_size))
+                            jsonData[item], propDict['typeprops'].propList, refDict, prefix + item + '.', context,
+                            linklimits=linklimits, sample_size=sample_size))
         traverseLogger.debug(str(linkList))
     except Exception as ex:
         traverseLogger.exception("Something went wrong")

--- a/traverseService.py
+++ b/traverseService.py
@@ -10,6 +10,7 @@ import sys
 import re
 import os
 import json
+import random
 from collections import OrderedDict
 from functools import lru_cache
 import logging
@@ -39,13 +40,13 @@ def getLogger():
 configset = {
         "targetip": type(""), "username": type(""), "password": type(""), "authtype": type(""), "usessl": type(True), "certificatecheck": type(True), "certificatebundle": type(""),
         "metadatafilepath": type(""), "cachemode": (type(False),type("")), "cachefilepath": type(""), "schemasuffix": type(""), "timeout": type(0), "httpproxy": type(""), "httpsproxy": type(""),
-        "systeminfo": type(""), "localonlymode": type(True), "servicemode": type(True), "token": type(""), 'linklimit': dict
+        "systeminfo": type(""), "localonlymode": type(True), "servicemode": type(True), "token": type(""), 'linklimit': dict, 'sample': type(0)
         }
 config = {
         'authtype': 'basic', 'username': "", 'password': "", 'token': '',
         'certificatecheck': True, 'certificatebundle': "", 'metadatafilepath': './SchemaFiles/metadata',
         'cachemode': 'Off', 'cachefilepath': './cache', 'schemasuffix': '_v1.xml', 'httpproxy': "", 'httpsproxy': "",
-        'localonlymode': False, 'servicemode': False, 'linklimit': {'LogEntry':20}
+        'localonlymode': False, 'servicemode': False, 'linklimit': {'LogEntry':20}, 'sample': 0
         }
 
 def setConfig(cdict):
@@ -577,9 +578,11 @@ class ResourceObj:
 
         self.links = OrderedDict()
         node = self.typeobj
+
         while node is not None:
             self.links.update(getAllLinks(
-                self.jsondata, node.propList, node.refs, context=expectedSchema, linklimits=config['linklimit']))
+                self.jsondata, node.propList, node.refs, context=expectedSchema, linklimits=config['linklimit'],
+                sample_size=config['sample']))
             node = node.parent
 
 
@@ -883,7 +886,38 @@ def getPropertyDetails(soup, refs, propOwner, propChild, tagType='EntityType', t
     return propEntry
 
 
-def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=None):
+def enumerate_collection(items, cTypeName, linklimits, sample_size):
+    """
+    Generator function to enumerate the the items in a collection, applying the link limit or sample size if applicable.
+    If a link limit is specified for this cTypeName, return the first N items as specified by the limit value.
+    If a sample size greater than zero is specified, return a random sample of items specified by the sample_size.
+    In both the above cases, if the limit value or sample size is greater than or equal to the number of items in the
+    collection, return all the items.
+    If a limit value and sample size are both provided, the limit value takes precedence.
+    :param items: the collection of items to enumerate
+    :param cTypeName: the type name of this collection
+    :param linklimits: a dictionary mapping type names to their limit values
+    :param sample_size: the number of items to sample from large collections
+    :return: enumeration of the items to be processed
+    """
+    if cTypeName in linklimits:
+        # "link limit" case
+        limit = min(linklimits[cTypeName], len(items))
+        traverseLogger.debug('Limiting "{}" to first {} links'.format(cTypeName, limit))
+        for i in range(limit):
+            yield i, items[i]
+    elif 0 < sample_size < len(items):
+        # "sample size" case
+        traverseLogger.debug('Limiting "{}" to sample of {} links'.format(cTypeName, sample_size))
+        for i in sorted(random.sample(range(len(items)), sample_size)):
+            yield i, items[i]
+    else:
+        # "all" case
+        traverseLogger.debug('Processing all links for "{}"'.format(cTypeName))
+        yield from enumerate(items)
+
+
+def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=None, sample_size=0):
     # gets all links, this can miss something if it is not designated navigatable or properly autoextended, collections, etc
     # info: works underneath, can maybe report how many links it has gotten or leave that to whatever calls it?
     # debug: should be reported by what calls it?  not much debug is neede besides what is already generated earlier, 
@@ -929,12 +963,7 @@ def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=N
                         cSchema = refDict.get(getNamespace(cType), (None, None))[1]
                         if cSchema is None:
                             cSchema = context
-                        for cnt, listItem in enumerate(insideItem):
-                            # starts at 0...
-                            if cTypeName in linklimits:
-                                if cnt >= linklimits[cTypeName]:
-                                    traverseLogger.debug("Truncating Links of {}".format(cTypeName))
-                                    break
+                        for cnt, listItem in enumerate_collection(insideItem, cTypeName, linklimits, sample_size):
                             linkList[prefix + str(item) + '.' + getType(propDict['isCollection']) +
                                      '#' + str(cnt)] = (listItem.get('@odata.id'), autoExpand, cType, cSchema, listItem)
                     else:
@@ -967,17 +996,12 @@ def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=N
                     cType = propDict.get('isCollection')
                     if cType is not None:
                         cTypeName = getType(cType)
-                        for cnt, listItem in enumerate(jsonData[item]):
-                            # starts at 0...
-                            if cTypeName in linklimits:
-                                if cnt >= linklimits[cTypeName]:
-                                    traverseLogger.debug("Truncating Links of {}".format(cTypeName))
-                                    break
+                        for cnt, listItem in enumerate_collection(jsonData[item], cTypeName, linklimits, sample_size):
                             linkList.update(getAllLinks(
-                                listItem, propDict['typeprops'].propList, refDict, prefix + item + '.', context))
+                                listItem, propDict['typeprops'].propList, refDict, prefix + item + '.', context, sample_size=sample_size))
                     else:
                         linkList.update(getAllLinks(
-                            jsonData[item], propDict['typeprops'].propList, refDict, prefix + item + '.', context))
+                            jsonData[item], propDict['typeprops'].propList, refDict, prefix + item + '.', context, sample_size=sample_size))
         traverseLogger.debug(str(linkList))
     except Exception as ex:
         traverseLogger.exception("Something went wrong")


### PR DESCRIPTION
Add sampling support for large collections:
- added `--sample N` command-line option and `Sample = N` config.ini property to specify sample size
- the default is to validate all collection members
- if the sample size is greater than or equal to the collection size, all members are validated (no sampling)
- a sample size of zero (or less than zero) means to validate all members (no sampling)
- if both link limit and sample size apply to a given collection, link limit takes precedence

Fixes #100 

Here is some debug output showing a mix of link limit and sampling being performed (Sample = 5, LinkLimit = {LogEntry:20}):

```
DEBUG - Limiting "SoftwareInventory" to sample of 5 links
DEBUG - Limiting "Voltage" to sample of 5 links
DEBUG - Limiting "IPv6Address" to sample of 5 links
DEBUG - Limiting "LogEntry" to first 20 links
DEBUG - Limiting "LogEntry" to first 20 links
DEBUG - Limiting "ManagerAccount" to sample of 5 links
DEBUG - Limiting "Attributes" to sample of 5 links
DEBUG - Limiting "Menus" to sample of 5 links
DEBUG - Limiting "Dependencies" to sample of 5 links
DEBUG - Limiting "JsonSchemaFile" to sample of 5 links
``` 

And here is a screenshot showing a random sample of 5 Voltage entries (out of 26) being validated:

![screen shot 2017-11-28 at 12 26 10 pm](https://user-images.githubusercontent.com/3341721/33337113-9066ca12-d437-11e7-9f78-52df968d3585.png)
