### PR TITLE
HTML report improvements for issue 137, part 1

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -16,6 +16,8 @@ import logging
 import json
 import traverseService as rst
 
+tool_version = 0.91
+
 rsvLogger = rst.getLogger()
 
 attributeRegistries = dict()
@@ -1327,6 +1329,7 @@ def main(argv=None):
             .pass {background-color:#99EE99}\
             .fail {background-color:#EE9999}\
             .warn {background-color:#EEEE99}\
+            .bluebg {background-color:#BDD6EE}\
             .button {padding: 12px; display: inline-block}\
             .center {text-align:center;}\
             .log {text-align:left; white-space:pre-wrap; word-wrap:break-word; font-size:smaller}\
@@ -1342,26 +1345,51 @@ def main(argv=None):
             .titletable {width:100%}\
             </style>\
             </head>'
-            
 
-    htmlStrBodyHeader = '<body><table>\
-                <tr><th>##### Redfish Conformance Test Report #####</th></tr>\
-                <tr><th>System: ' + ConfigURI + '</th></tr>\
-                <tr><th>Description: ' + sysDescription + '</th></tr>\
-                <tr><th>' + str(config_str.replace('\n', '</br>')) + '</th></tr>\
-                <tr><th>Start time: ' + (startTick).strftime('%x - %X') + '</th></tr>\
-                <tr><th>Run time: ' + str(nowTick-startTick).rsplit('.', 1)[0] + '</th></tr>\
-                <tr><th></th></tr>'
+    htmlStrBodyHeader = \
+        '<body><table><tr><th>' \
+        '<h2>##### Redfish Conformance Test Report #####</h2>' \
+        '<br>' \
+        '<h4><img align="center" alt="DMTF Redfish Logo" height="203" width="288"' \
+        'src="http://redfish.dmtf.org/sites/default/files/DMTF_Redfish_logo_R.jpg"></h4>' \
+        '<br>' \
+        '<h4><a href="https://github.com/DMTF/Redfish-Service-Validator">' \
+        'https://github.com/DMTF/Redfish-Service-Validator</a>' \
+        '<br>Tool Version: ' + str(tool_version) + \
+        '<br>' + startTick.strftime('%c') + \
+        '<br>(Run time: ' + str(nowTick-startTick).rsplit('.', 1)[0] + ')' \
+        '' \
+        '<h4>This tool is provided and maintained by the DMTF. ' \
+        'For feedback, please open issues<br>in the tool’s Github repository: ' \
+        '<a href="https://github.com/DMTF/Redfish-Service-Validator/issues">' \
+        'https://github.com/DMTF/Redfish-Service-Validator/issues</a></h4>' \
+        '</th></tr>' \
+        '<tr><th>' \
+        '<h4>System: <a href="' + ConfigURI + '">' + ConfigURI + '</a> Description: ' + sysDescription + '</h4>' \
+        '</th></tr>' \
+        '<tr><th>' \
+        '<h4>Configuration:</h4>' \
+        '<h4>' + str(config_str.replace('\n', '<br>')) + '</h4>' \
+        '</th></tr>' \
+        ''
 
     htmlStr = ''
 
     rsvLogger.info(len(results))
     for cnt, item in enumerate(results):
+        type_name = ''
+        prop_type = results[item][6]
+        if prop_type is not None:
+            namespace = prop_type.replace('#', '').rsplit('.', 1)[0]
+            type_name = prop_type.replace('#', '').rsplit('.', 1)[-1]
+            if '.' in namespace:
+                type_name += ' ' + namespace.split('.', 1)[-1]
+        htmlStr += '<tr><th class="titlerow bluebg"><b>{}</b> ({})</th></tr>'.format(results[item][0], type_name)
         htmlStr += '<tr><td class="titlerow"><table class="titletable"><tr>'
         htmlStr += '<td class="title" style="width:40%"><div>{}</div>\
                 <div class="button warn" onClick="document.getElementById(\'resNum{}\').classList.toggle(\'resultsShow\');">Show results</div>\
                 </td>'.format(results[item][0], cnt, cnt)
-        htmlStr += '<td class="titlesub log" style="width:30%"><div><b>ResourcePath:</b> {}</div><div><b>XML:</b> {}</div><div><b>type:</b> {}</div></td>'.format(item, results[item][5], results[item][6])
+        htmlStr += '<td class="titlesub log" style="width:30%"><div><b>Schema File:</b> {}</div><div><b>Resource Type:</b> {}</div></td>'.format(results[item][5], type_name)
         htmlStr += '<td style="width:10%"' + \
             ('class="pass"> GET Success' if results[item]
              [1] else 'class="fail"> GET Failure') + '</td>'

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -693,12 +693,12 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
             rsvLogger.info('\tItem is skipped, no schema')
             counts['skipNoSchema'] += 1
             return {item: ('-', '-',
-                                'Yes' if propExists else 'No', 'skipNoSchema')}, counts
+                                'Yes' if propExists else 'No', 'NoSchema')}, counts
         else:
             rsvLogger.error('\tItem is present, no schema found')
             counts['failNoSchema'] += 1
             return {item: ('-', '-',
-                                'Yes' if propExists else 'No', 'failNoSchema')}, counts
+                                'Yes' if propExists else 'No', 'FAIL')}, counts
 
     propAttr = PropertyItem['attrs']
 
@@ -712,7 +712,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
         rsvLogger.info('\tOem is skipped')
         counts['skipOem'] += 1
         return {item: ('-', '-',
-                            'Yes' if propExists else 'No', 'skipOEM')}, counts
+                            'Yes' if propExists else 'No', 'OEM')}, counts
 
     propMandatory = False
     propMandatoryPass = True
@@ -730,7 +730,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
             return {item: (
                 '-', displayType(propType, propRealType),
                 'Yes' if propExists else 'No',
-                'skipOptional')}, counts
+                'Optional')}, counts
 
     nullable_attr = propAttr.get('Nullable')
     propNullable = False if nullable_attr == 'false' else True  # default is true
@@ -766,7 +766,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
         return {item: (
             '-', displayType(propType, propRealType),
             'Yes' if propExists else 'No',
-            'failNullCollection')}, counts
+            'FAIL')}, counts
     elif isCollection and propValue is not None:
         # note: handle collections correctly, this needs a nicer printout
         # rs-assumption: do not assume URIs for collections
@@ -825,7 +825,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
                         resultList[item + appendStr] = (
                                     'ComplexDictionary' + appendStr, displayType(propType, propRealType),
                                     'Yes' if propExists else 'No',
-                                    'failComplex')
+                                    'FAIL')
                         continue
                     resultList[item + appendStr] = (
                                     'ComplexDictionary' + appendStr, displayType(propType, propRealType),
@@ -843,12 +843,12 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
                             resultList[item + '.' + key + appendStr] = (
                                     val[key], '-',
                                     '-',
-                                    'failAdditional')
+                                    'FAIL')
                         elif key not in complexMessages:
                             counts['unverifiedComplexAdditional'] += 1
                             resultList[item + '.' + key + appendStr] = (val[key], '-',
                                              '-',
-                                             'skipAdditional')
+                                             'Additional')
                     continue
 
                 elif propRealType == 'enum':
@@ -1052,12 +1052,12 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
                 counts['failAdditional'] += 1
                 messages[key] = (item, '-',
                                  '-',
-                                 'failAdditional')
+                                 'FAIL')
             else:
                 counts['unverifiedAdditional'] += 1
                 messages[key] = (item, '-',
                                  '-',
-                                 'skipAdditional')
+                                 'Additional')
 
     for key in messages:
         if key not in jsonData:
@@ -1360,7 +1360,7 @@ def main(argv=None):
                 success_col = results[item][3][i][-1]
                 if 'FAIL' in str(success_col).upper():
                     htmlStr += '<td class="fail center">' + str(success_col) + '</td>'
-                elif 'SKIP' in str(success_col).upper():
+                elif 'DEPRECATED' in str(success_col).upper():
                     htmlStr += '<td class="warn center">' + str(success_col) + '</td>'
                 elif 'PASS' in str(success_col).upper():
                     htmlStr += '<td class="pass center">' + str(success_col) + '</td>'

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1349,7 +1349,7 @@ def main(argv=None):
                     style='class="fail log"' if 'fail' in countType or 'exception' in countType else 'class=log')
         htmlStr += '</td></tr>'
         htmlStr += '</table></td></tr>'
-        htmlStr += '<tr><td class="results" id=\'resNum{}\'><table><tr><td><table><tr><th style="width:15%"> Name</th> <th> Value</th> <th>Type</th> <th style="width:10%">Exists?</th> <th style="width:10%">Success</th> <tr>'.format(cnt)
+        htmlStr += '<tr><td class="results" id=\'resNum{}\'><table><tr><td><table><tr><th style="width:15%">Property Name</th> <th>Value</th> <th>Type</th> <th style="width:10%">Exists?</th> <th style="width:10%">Result</th> <tr>'.format(cnt)
         if results[item][3] is not None:
             for i in results[item][3]:
                 htmlStr += '<tr>'

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -67,7 +67,7 @@ def validateActions(name, val, propTypeObj, payloadType):
                 rsvLogger.warn('{}: action not Found, is not mandatory'.format(k))
         actionMessages[k] = (
                     'Action', '-',
-                    'Exists' if actionDecoded != 'n/a' else 'DNE',
+                    'Yes' if actionDecoded != 'n/a' else 'No',
                     'PASS' if actPass else 'FAIL')
         if actPass:
             actionCounts['pass'] += 1
@@ -448,7 +448,7 @@ def validateDynamicPropertyPatterns(name, val, propTypeObj, payloadType, attrReg
             else:
                 counts['failAttributeRegistry'] += 1
         messages[key + ' '] = (
-            value, prop_type if attr_reg_type is None else attr_reg_type, 'Exists',
+            value, prop_type if attr_reg_type is None else attr_reg_type, 'Yes',
             'PASS' if type_pass and pattern_pass and reg_pass else 'FAIL')
 
     return messages, counts
@@ -693,12 +693,12 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
             rsvLogger.info('\tItem is skipped, no schema')
             counts['skipNoSchema'] += 1
             return {item: ('-', '-',
-                                'Exists' if propExists else 'DNE', 'skipNoSchema')}, counts
+                                'Yes' if propExists else 'No', 'skipNoSchema')}, counts
         else:
             rsvLogger.error('\tItem is present, no schema found')
             counts['failNoSchema'] += 1
             return {item: ('-', '-',
-                                'Exists' if propExists else 'DNE', 'failNoSchema')}, counts
+                                'Yes' if propExists else 'No', 'failNoSchema')}, counts
 
     propAttr = PropertyItem['attrs']
 
@@ -712,7 +712,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
         rsvLogger.info('\tOem is skipped')
         counts['skipOem'] += 1
         return {item: ('-', '-',
-                            'Exists' if propExists else 'DNE', 'skipOEM')}, counts
+                            'Yes' if propExists else 'No', 'skipOEM')}, counts
 
     propMandatory = False
     propMandatoryPass = True
@@ -729,7 +729,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
             counts['skipOptional'] += 1
             return {item: (
                 '-', displayType(propType, propRealType),
-                'Exists' if propExists else 'DNE',
+                'Yes' if propExists else 'No',
                 'skipOptional')}, counts
 
     nullable_attr = propAttr.get('Nullable')
@@ -765,7 +765,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
         counts['failNullCollection'] += 1
         return {item: (
             '-', displayType(propType, propRealType),
-            'Exists' if propExists else 'DNE',
+            'Yes' if propExists else 'No',
             'failNullCollection')}, counts
     elif isCollection and propValue is not None:
         # note: handle collections correctly, this needs a nicer printout
@@ -774,7 +774,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
         # rs-assumption: check @odata.link property
         rsvLogger.info("\tis Collection")
         resultList[item] = ('Collection, size: ' + str(len(propValue)), displayType(propType, propRealType),
-                            'Exists' if propExists else 'DNE',
+                            'Yes' if propExists else 'No',
                             '...')
         propValueList = propValue
     else:
@@ -824,12 +824,12 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
                         counts['failComplex'] += 1
                         resultList[item + appendStr] = (
                                     'ComplexDictionary' + appendStr, displayType(propType, propRealType),
-                                    'Exists' if propExists else 'DNE',
+                                    'Yes' if propExists else 'No',
                                     'failComplex')
                         continue
                     resultList[item + appendStr] = (
                                     'ComplexDictionary' + appendStr, displayType(propType, propRealType),
-                                    'Exists' if propExists else 'DNE',
+                                    'Yes' if propExists else 'No',
                                     'complex')
 
                     counts.update(complexCounts)
@@ -842,12 +842,12 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
                             counts['failComplexAdditional'] += 1
                             resultList[item + '.' + key + appendStr] = (
                                     val[key], '-',
-                                    'Exists (additional)',
+                                    '-',
                                     'failAdditional')
                         elif key not in complexMessages:
                             counts['unverifiedComplexAdditional'] += 1
                             resultList[item + '.' + key + appendStr] = (val[key], '-',
-                                             'Exists (additional.ok)',
+                                             '-',
                                              'skipAdditional')
                     continue
 
@@ -865,7 +865,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
 
         resultList[item + appendStr] = (
                 val, displayType(propType, propRealType),
-                'Exists' if propExists else 'DNE',
+                'Yes' if propExists else 'No',
                 'PASS' if paramPass and propMandatoryPass and propNullablePass else 'FAIL')
         if paramPass and propNullablePass and propMandatoryPass:
             counts['pass'] += 1
@@ -924,7 +924,7 @@ def checkPayloadConformance(uri, decoded):
             success = False
         messages[key] = (
                 decoded[key], display_type,
-                'Exists',
+                'Yes',
                 'PASS' if paramPass else 'FAIL')
     return success, messages
 
@@ -1051,12 +1051,12 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
                 rsvLogger.error('%s: Appears to be an extra property (check inheritance or casing?)', key)  # Printout FORMAT
                 counts['failAdditional'] += 1
                 messages[key] = (item, '-',
-                                 'Exists (add.)',
+                                 '-',
                                  'failAdditional')
             else:
                 counts['unverifiedAdditional'] += 1
                 messages[key] = (item, '-',
-                                 'Exists (add.ok)',
+                                 '-',
                                  'skipAdditional')
 
     for key in messages:


### PR DESCRIPTION
Includes these improvements for #137:
- In the resource report tables, improves readability for fields in the Name, Value, Types, Exists and Result columns
- In the header section, improved readability and formatting

Work still remaining for #137:
- If property, enum, etc. not found in schema, do a case-insensitive check to report case errors
- Make Configuration section human readable and collapse the less-important settings
- Make Final Counts section a Test Summary section and make it more human readable
- Continue making enhancements described in #137 under "Header improvements", item (7)
- All items described in #137 under "Error case enhancements"

**Header BEFORE:**

![screen shot 2018-01-25 at 2 59 53 pm](https://user-images.githubusercontent.com/3341721/35412889-5b76c846-01e3-11e8-86fd-9179ba837058.png)

**Header AFTER:**

![screen shot 2018-01-25 at 3 00 11 pm](https://user-images.githubusercontent.com/3341721/35412911-6cf41baa-01e3-11e8-96f5-88f4b258ad12.png)

**ServiceRoot BEFORE:**

![screen shot 2018-01-25 at 3 03 20 pm](https://user-images.githubusercontent.com/3341721/35412930-7908b504-01e3-11e8-9343-63d2866641de.png)

**ServiceRoot AFTER:**

![screen shot 2018-01-25 at 3 03 34 pm](https://user-images.githubusercontent.com/3341721/35412948-853f6692-01e3-11e8-9016-982bd806c703.png)

**Systems BEFORE:**

![screen shot 2018-01-25 at 3 05 18 pm](https://user-images.githubusercontent.com/3341721/35412959-8da4686e-01e3-11e8-8378-be5ce4eb38aa.png)

**Systems AFTER:**

![screen shot 2018-01-25 at 3 05 38 pm](https://user-images.githubusercontent.com/3341721/35412972-9513d3be-01e3-11e8-9cfa-ddce825f8c29.png)

