### PR TITLE
Update proxies to only apply to URLs external to the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,23 @@ Modify the config\config.ini file to enter the system details under below sectio
 
 [SystemInformation]
 
-TargetIP = <<IPv4 address of the system under test>>
+TargetIP = \<IPv4 address of the system under test\>
 
-SystemInfo = <<Describes the system>>
+SystemInfo = \<Describes the system\>
 
-UserName = <<User ID of Administrator on the system>>
+UserName = \<User ID of Administrator on the system\>
 
-Password = <<Password of the Administrator>>
+Password = \<Password of the Administrator\>
 
-AuthType = <<Type of authorization for above credentials (None,Basic,Session)>>
+AuthType = \<Type of authorization for above credentials (None,Basic,Session)\>
 
 The Tool has an option to ignore SSL certificate check if certificate is not installed on the client system. The certificate check can be switched on or off using the below parameter of the config.ini file. By default the parameter is set to ‘Off’.  UseSSL determines whether or not the https protocol is used.  If it is `Off`, it will also disable certification.
 
 [Options]
 
-UseSSL = <<On / Off>>
+UseSSL = \<On / Off\>
 
-CertificateCheck = <<On / Off>>
+CertificateCheck = \<On / Off\>
 
 CertificateBundle = ca_bundle   Specify a bundle (file or directory) with certificates of trusted CAs. See [SelfSignedCerts.md](https://github.com/DMTF/Redfish-Service-Validator/blob/master/SelfSignedCerts.md) for tips on creating the bundle.
 
@@ -73,11 +73,13 @@ Timeout - (integer) Interval of time before timing out
 
 SchemaSuffix - (string) When searching for local hard drive schema, append this if unable to derive the expected xml from the service's metadata
 
-HttpProxy - Proxy for http gets (untested)
+HttpProxy - (URL) Proxy for HTTP requests to external URLs (example: `HttpProxy = http://192.168.1.1:8888`)
 
-HttpsProxy - Proxy for https gets (untested)
+HttpsProxy - (URL) Proxy for HTTPS requests to external URLs (example: `HttpsProxy = http://192.168.1.1:8888`)
 
-Additional options are available for cached files and 
+Note: HttpProxy/HttpsProxy do not apply to requests to the system under test, only to URLs external to the system.
+
+Additional options are available for cached files, link limits, sampling and target payloads:
 
 CacheMode = [Off, Prefer, Fallback] -- Options for using a cache, which will allow a user to override or fallback to a file on disk during a resource call on a service
 

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1323,7 +1323,7 @@ def main(argv=None):
         rsvLogger.error('PayloadMode or path invalid, using Default behavior')
     if 'File' in pmode:
         if ppath is not None and os.path.isfile(ppath):
-            with open(cdict.get(ppath)) as f:
+            with open(ppath) as f:
                 jsonData = json.load(f)
                 f.close()
         else:

--- a/traverseService.py
+++ b/traverseService.py
@@ -100,7 +100,8 @@ def setConfig(cdict):
 
     if AuthType == 'Session':
         certVal = chkcertbundle if ChkCert and chkcertbundle is not None else ChkCert
-        success = currentSession.startSession(User, Passwd, config['configuri'], certVal, proxies)
+        # no proxy for system under test
+        success = currentSession.startSession(User, Passwd, config['configuri'], certVal, proxies=None)
         if not success:
             raise RuntimeError("Session could not start")
 
@@ -220,7 +221,8 @@ def callResourceURI(URILink):
         if payload is not None and CacheMode == 'Prefer':
             return True, payload, -1, 0
         response = requests.get(ConfigURI + URILink if not nonService else URILink,
-                                headers=headers, auth=auth, verify=certVal, timeout=timeout, proxies=proxies)
+                                headers=headers, auth=auth, verify=certVal, timeout=timeout,
+                                proxies=proxies if nonService else None)  # only proxy non-service
         expCode = [200]
         elapsed = response.elapsed.total_seconds()
         statusCode = response.status_code


### PR DESCRIPTION
Per discussion in issue #76, updated code to only use proxies for URLs external to the service being tested.

I tested the proxy feature using the Charles proxy and confirmed it is working as expected.

Also fixed an unrelated bug with the handling of SingleFile payload mode that I saw during testing.

Fixes #76 