### PR TITLE
Fix to complex types not assuming highest type, +deprecate tag check

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -700,6 +700,11 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs):
     validMinAttr = PropertyItem.get('Validation.Minimum')
     validMaxAttr = PropertyItem.get('Validation.Maximum')
 
+    # <Annotation Term="Redfish.Deprecated" String="This property has been Deprecated in favor of Thermal.v1_1_0.Thermal.Fan.Name"/>
+    validDeprecated = PropertyItem.get('Redfish.Deprecated') 
+    if validDeprecated is not None:
+        rsvLogger.error('{}: The given property is deprecated: {}'.format(PropertyName, validDeprecated.get('String','')))
+
     validMin, validMax = int(validMinAttr['Int']) if validMinAttr is not None else None, \
         int(validMaxAttr['Int']) if validMaxAttr is not None else None
     validPattern = validPatternAttr.get('String', '') if validPatternAttr is not None else None

--- a/traverseService.py
+++ b/traverseService.py
@@ -846,7 +846,8 @@ def getPropertyDetails(soup, refs, propertyOwner, propertyName, ownerTagType='En
         if PropertyNamespace.split('.')[0] != OwnerNamespace.split('.')[0]:
             success, propertySoup, uri = getSchemaDetails(
                 *refs.get(PropertyNamespace, (None, None)))
-            propertyRefs = getReferenceDetails(propertySoup, refs, name=uri)
+            if success:
+                propertyRefs = getReferenceDetails(propertySoup, refs, name=uri)
         else:
             success, propertySoup, uri = True, soup, 'of parent'
 


### PR DESCRIPTION
Commit rewrites certain variable names in getPropertyDetails, and corrects the issue of ComplexTypes not gathering all their properties.

Fixes #160 

Commit adds check for deprecated tag as well.