### PR TITLE
Ensure resource header shows failure if any errors logged for resource

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1416,6 +1416,19 @@ def main(argv=None):
 
         innerCounts = results[item][2]
         finalCounts.update(innerCounts)
+
+        # detect if there are error messages for this resource, but no failure counts; if so, add one to the innerCounts
+        counters_all_pass = True
+        for countType in sorted(innerCounts.keys()):
+            if 'problem' in countType or 'fail' in countType or 'exception' in countType:
+                counters_all_pass = False
+                break
+        error_messages_present = False
+        if results[item][4] is not None and len(results[item][4].getvalue()) > 0:
+            error_messages_present = True
+        if counters_all_pass and error_messages_present:
+            innerCounts['failSchema'] = 1
+
         for countType in sorted(innerCounts.keys()):
             if 'problem' in countType or 'fail' in countType or 'exception' in countType:
                 rsvLogger.error('{} {} errors in {}'.format(innerCounts[countType], countType, str(results[item][0]).split(' ')[0]))  # Printout FORMAT


### PR DESCRIPTION
When schema errors are logged via traverseService.py, the functions that module do not have access to the result counters for the resource being processed. So those errors show up in the report at the end of the resource section, but they are not accounted for in the summary counts in the header of the resource section.

This PR includes a tactical fix during report generation that checks for this condition and adds a failure counter to the resource summary so that it will be highlighted in red. This makes it obvious there is a problem with the resource even without expanding the details.

Fixes #151 
Fixes #154 
