### PR TITLE
Improve display of array member properties in report

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -277,7 +277,7 @@ def validateAttributeRegistry(name, key, value, attr_reg):
             reg_pass = value in val_list
             if not reg_pass:
                 rsvLogger.error(
-                    'Attribute {} has a value of {}. This is not an expected value from the Enumeration: {}'
+                    '{} has a value of {}. This is not an expected value from the Enumeration: {}'
                     .format(name + '.' + key, value, val_list))
         else:
             rsvLogger.debug('{}: Expected Value property key {} to be a list, found type {}'
@@ -287,7 +287,7 @@ def validateAttributeRegistry(name, key, value, attr_reg):
         reg_pass = isinstance(value, str)
         if not reg_pass:
             rsvLogger.error(
-                'Attribute {} has a value of {}. The expected type is String but the type found is {}'
+                '{} has a value of {}. The expected type is String but the type found is {}'
                 .format(name + '.' + key, value, str(type(value)).strip('<>')))
         else:
             # validate MaxLength
@@ -297,11 +297,11 @@ def validateAttributeRegistry(name, key, value, attr_reg):
                     if len(value) > max_len:
                         reg_pass = False
                         rsvLogger.error(
-                            'The length of attribute {} is {}, which is greater than its MaxLength of {}'
+                            '{} has a length of {}, which is greater than its MaxLength of {}'
                             .format(name + '.' + key, len(value), max_len))
                 else:
                     reg_pass = False
-                    rsvLogger.error('The MaxLength property in {} should be an int but the type found is {}'
+                    rsvLogger.error('{} should have a MaxLength property that is an integer, but the type found is {}'
                                     .format(name + '.' + key, str(type(max_len)).strip('<>')))
             # validate MinLength
             min_len = attr.get('MinLength')
@@ -309,11 +309,11 @@ def validateAttributeRegistry(name, key, value, attr_reg):
                 if isinstance(min_len, int):
                     if len(value) < min_len:
                         reg_pass = False
-                        rsvLogger.error('The length of attribute {} is {}, which is less than its MinLength of {}'
+                        rsvLogger.error('{} has a length of {}, which is less than its MinLength of {}'
                                         .format(name + '.' + key, len(value), min_len))
                 else:
                     reg_pass = False
-                    rsvLogger.error('The MinLength property in {} should be an int but the type found is {}'
+                    rsvLogger.error('{} should have a MinLength property that is an integer, but the type found is {}'
                                     .format(name + '.' + key, str(type(min_len)).strip('<>')))
             # validate ValueExpression
             val_expr = attr.get('ValueExpression')
@@ -323,19 +323,19 @@ def validateAttributeRegistry(name, key, value, attr_reg):
                     if regex.match(value) is None:
                         reg_pass = False
                         rsvLogger.error(
-                            'The value of attribute {} is {} which does not match ValueExpression regex "{}"'
+                            '{} has a value of {} which does not match the ValueExpression regex "{}"'
                             .format(name + '.' + key, value, val_expr))
                 else:
                     reg_pass = False
                     rsvLogger.error(
-                        'The ValueExpression property in {} should be a string but the type found is {}'
+                        '{} should have a ValueExpression property that is a string, but the type found is {}'
                         .format(name + '.' + key, str(type(val_expr)).strip('<>')))
     elif type_prop == 'Integer':
         # validate type is int
         reg_pass = isinstance(value, int)
         if not reg_pass:
             rsvLogger.error(
-                'Attribute {} has a value of {}. The expected type is Integer but the type found is {}'
+                '{} has a value of {}. The expected type is Integer but the type found is {}'
                 .format(name + '.' + key, value, str(type(value)).strip('<>')))
         else:
             # validate LowerBound
@@ -343,38 +343,38 @@ def validateAttributeRegistry(name, key, value, attr_reg):
             if isinstance(lower_bound, int):
                 if value < lower_bound:
                     reg_pass = False
-                    rsvLogger.error('The value of attribute {} is {}, which is less than its LowerBound of {}'
+                    rsvLogger.error('{} has a value of {}, which is less than its LowerBound of {}'
                                     .format(name + '.' + key, value, lower_bound))
             else:
                 reg_pass = False
-                rsvLogger.error('The LowerBound property in {} should be an int but the type found is {}'
+                rsvLogger.error('{} should have a LowerBound property that is an integer, but the type found is {}'
                                 .format(name + '.' + key, str(type(lower_bound)).strip('<>')))
             # validate UpperBound
             upper_bound = attr.get('UpperBound')
             if isinstance(upper_bound, int):
                 if value > upper_bound:
                     reg_pass = False
-                    rsvLogger.error('The value of attribute {} is {}, which is greater than its UpperBound of {}'
+                    rsvLogger.error('{} has a value of {}, which is greater than its UpperBound of {}'
                                     .format(name + '.' + key, value, upper_bound))
             else:
                 reg_pass = False
-                rsvLogger.error('The UpperBound property in {} should be an int but the type found is {}'
+                rsvLogger.error('{} should have an UpperBound property that is an integer, but the type found is {}'
                                 .format(name + '.' + key, str(type(upper_bound)).strip('<>')))
     elif type_prop == 'Boolean':
         reg_pass = isinstance(value, bool)
         if not reg_pass:
             rsvLogger.error(
-                'Attribute {} has a value of {}. The expected type is Boolean but the type found is {}'
+                '{} has a value of {}. The expected type is Boolean but the type found is {}'
                 .format(name + '.' + key, value, str(type(value)).strip('<>')))
     elif type_prop == 'Password':
         reg_pass = value is None
         if not reg_pass:
             rsvLogger.error(
-                'Attribute {} is a Password. The value returned from GET must be null, but was of type {}'
+                '{} is a Password. The value returned from GET must be null, but was of type {}'
                 .format(name + '.' + key, str(type(value)).strip('<>')))
     else:
-        rsvLogger.warning('Unexpected Type property {} found for key {}'
-                          .format(type_prop, name + '.' + key))
+        rsvLogger.warning('{} has an unexpected Type property of {}'
+                          .format(name + '.' + key, type_prop))
     return reg_pass, type_prop
 
 
@@ -423,7 +423,7 @@ def validateDynamicPropertyPatterns(name, val, propTypeObj, payloadType, attrReg
             rsvLogger.debug('{}: {}: Using default attribute registry for {}'.format(fn, name, attrRegistryId))
             attr_reg = attributeRegistries.get('default')
         else:
-            rsvLogger.warning('{}: {}: Attribute Registry with ID {} not found'.format(fn, name, attrRegistryId))
+            rsvLogger.warning('{}: Attribute Registry with ID {} not found'.format(name, attrRegistryId))
     else:
         rsvLogger.debug('{}: {}: No Attribute Registry ID found'.format(fn, name, attrRegistryId))
     # validate each property
@@ -555,17 +555,21 @@ def validateDeprecatedEnum(name, val, listEnum):
     """
     paramPass = True
     if isinstance(val, list):
+        display_val = []
         for enumItem in val:
+            display_val.append(dict(enumItem))
             for k, v in enumItem.items():
                 paramPass = paramPass and str(v) in listEnum
         if not paramPass:
-            rsvLogger.error("{}: Invalid DeprecatedEnum, expected {}".format(str(name), str(listEnum)))
+            rsvLogger.error("{}: Invalid DeprecatedEnum value '{}' found, expected {}"
+                            .format(str(name), display_val, str(listEnum)))
     elif isinstance(val, str):
         paramPass = str(val) in listEnum
         if not paramPass:
-            rsvLogger.error("{}: Invalid DeprecatedEnum, expected {}".format(str(name), str(listEnum)))
+            rsvLogger.error("{}: Invalid DeprecatedEnum value '{}' found, expected {}"
+                            .format(str(name), val, str(listEnum)))
     else:
-        rsvLogger.error("{}: Expected list/str value for DeprecatedEnum, got {}".format(str(name), str(type(val)).strip('<>')))
+        rsvLogger.error("{}: Expected list or string value for DeprecatedEnum, got {}".format(str(name), str(type(val)).strip('<>')))
     return paramPass
 
 
@@ -576,7 +580,7 @@ def validateEnum(name, val, listEnum):
         if not paramPass:
             rsvLogger.error("{}: Invalid Enum value '{}' found, expected {}".format(str(name), val, str(listEnum)))
     else:
-        rsvLogger.error("{}: Expected str value for Enum, got {}".format(str(name), str(type(val)).strip('<>')))
+        rsvLogger.error("{}: Expected string value for Enum, got {}".format(str(name), str(type(val)).strip('<>')))
     return paramPass
 
 
@@ -946,7 +950,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs, Pa
                 rsvLogger.error("%s: Mandatory prop does not exist" % sub_item)  # Printout FORMAT
                 counts['failMandatoryExist'] += 1
             elif not propNullablePass:
-                rsvLogger.error('Property {} is null but is not Nullable'
+                rsvLogger.error('{}: property is null but is not Nullable'
                                 .format(sub_item))
                 counts['failNullable'] += 1
             rsvLogger.info("\tFAIL")  # Printout FORMAT
@@ -1345,7 +1349,7 @@ def main(argv=None):
                 jsonData = json.load(f)
                 f.close()
         else:
-            rsvLogger.error('File not found {}'.format(ppath))
+            rsvLogger.error('File not found: {}'.format(ppath))
             return 1
     if 'Single' in pmode:
         success, counts, results, xlinks, topobj = validateSingleURI(ppath, 'Target', expectedJson=jsonData)

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -44,7 +44,7 @@ def validateActions(name, val, propTypeObj, payloadType):
             actionsDict[keyname] = act
         success, baseSoup, baseRefs, baseType = rst.getParentType(baseSoup, baseRefs, baseType, 'EntityType')
 
-    # For each action found, check action dictionary for existence and compliance
+    # For each action found, check action dictionary for existence and conformance
     # No action is required unless specified, target is not required unless specified
     # (should check for viable parameters)
     for k in actionsDict:
@@ -58,7 +58,7 @@ def validateActions(name, val, propTypeObj, payloadType):
                 rsvLogger.warn('{}: target for action is missing'.format(name + '.' + k))
                 actPass = True
             else:
-                rsvLogger.error('{} : target for action is malformed, expected string got'
+                rsvLogger.error('{}: target for action is malformed; expected string, got {}'
                                 .format(name + '.' + k, str(type(target))))
         else:
             # <Annotation Term="Redfish.Required"/>
@@ -158,7 +158,7 @@ def validateComplex(name, val, propTypeObj, payloadType, attrRegistryId):
     """
     rsvLogger.info('\t***going into Complex')
     if not isinstance(val, dict):
-        rsvLogger.error(name + ' : Complex item not a dictionary')  # Printout FORMAT
+        rsvLogger.error(name + ': Complex item not a dictionary')  # Printout FORMAT
         return False, None, None
 
     # Check inside of complexType, treat it like an Entity
@@ -192,7 +192,7 @@ def validateComplex(name, val, propTypeObj, payloadType, attrRegistryId):
     complexMessages.update(odataMessages)
     if not successPayload:
         complexCounts['failComplexPayloadError'] += 1
-        rsvLogger.error('In complex {}:  payload error, @odata property noncompliant'.format(str(name)))
+        rsvLogger.error('{}: complex payload error, @odata property non-conformant'.format(str(name)))
     rsvLogger.info('\t***out of Complex')
     rsvLogger.info('complex {}'.format(str(complexCounts)))
     if name == 'Actions':
@@ -754,12 +754,12 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs, Pa
 
     if PropertyItem is None:
         if not propExists:
-            rsvLogger.info('\tItem is skipped, no schema')
+            rsvLogger.info('{}: Item is skipped, no schema'.format(item))
             counts['skipNoSchema'] += 1
             return {item: ('-', '-',
                                 'Yes' if propExists else 'No', 'NoSchema')}, counts
         else:
-            rsvLogger.error('\tItem is present, no schema found')
+            rsvLogger.error('{}: Item is present, but no schema found'.format(item))
             counts['failNoSchema'] += 1
             return {item: ('-', '-',
                                 'Yes' if propExists else 'No', 'FAIL')}, counts
@@ -816,7 +816,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs, Pa
     # <Annotation Term="Redfish.Deprecated" String="This property has been Deprecated in favor of Thermal.v1_1_0.Thermal.Fan.Name"/>
     validDeprecated = PropertyItem.get('Redfish.Deprecated') 
     if validDeprecated is not None:
-        rsvLogger.error('{}: The given property is deprecated: {}'.format(PropertyName, validDeprecated.get('String','')))
+        rsvLogger.error('{}: The given property is deprecated: {}'.format(item, validDeprecated.get('String','')))
 
     validMin, validMax = int(validMinAttr['Int']) if validMinAttr is not None else None, \
         int(validMaxAttr['Int']) if validMaxAttr is not None else None
@@ -829,8 +829,8 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs, Pa
     isCollection = propCollectionType is not None
     if isCollection and propValue is None:
         # illegal for a collection to be null
-        rsvLogger.error('Value of Collection property {} is null but Collections cannot be null, only their entries'
-                        .format(PropertyName))
+        rsvLogger.error('{}: Value of Collection property is null but Collections cannot be null, only their entries'
+                        .format(item))
         counts['failNullCollection'] += 1
         return {item: (
             '-', displayType(propType, propRealType, is_collection=True),
@@ -942,16 +942,14 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs, Pa
             counts['err.' + str(propType)] += 1
             if not paramPass:
                 if propMandatory:
-                    rsvLogger.error("%s: Mandatory prop has failed to check" % sub_item)  # Printout FORMAT
                     counts['failMandatoryProp'] += 1
                 else:
                     counts['failProp'] += 1
             elif not propMandatoryPass:
-                rsvLogger.error("%s: Mandatory prop does not exist" % sub_item)  # Printout FORMAT
+                rsvLogger.error("{}: Mandatory prop does not exist".format(sub_item))  # Printout FORMAT
                 counts['failMandatoryExist'] += 1
             elif not propNullablePass:
-                rsvLogger.error('{}: property is null but is not Nullable'
-                                .format(sub_item))
+                rsvLogger.error('{}: Property is null but is not Nullable'.format(sub_item))
                 counts['failNullable'] += 1
             rsvLogger.info("\tFAIL")  # Printout FORMAT
 
@@ -989,7 +987,7 @@ def checkPayloadConformance(uri, decoded, ParentItem=None):
         else:
             paramPass = True
         if not paramPass:
-            rsvLogger.error(prefix + key + " @odata item not compliant: " + decoded[key])  # Printout FORMAT
+            rsvLogger.error(prefix + key + " @odata item not conformant: " + decoded[key])  # Printout FORMAT
             success = False
         messages[prefix + key] = (
                 decoded[key], display_type,
@@ -1045,7 +1043,7 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
 
     if not successPayload:
         counts['failPayloadError'] += 1
-        rsvLogger.error(str(URI) + ':  payload error, @odata property noncompliant',)  # Printout FORMAT
+        rsvLogger.error(str(URI) + ': payload error, @odata property non-conformant',)  # Printout FORMAT
         # rsvLogger.removeHandler(errh)  # Printout FORMAT
         # return False, counts, results, None, propResourceObj
     # Generate dictionary of property info
@@ -1089,7 +1087,7 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
                 counts.update(propCounts)
             except Exception as ex:
                 rsvLogger.exception("Something went wrong")  # Printout FORMAT
-                rsvLogger.error('%s:  Could not finish check on this property' % (prop.name))  # Printout FORMAT
+                rsvLogger.error('%s: Could not finish check on this property' % (prop.name))  # Printout FORMAT
                 counts['exceptionPropCheck'] += 1
         node = node.parent
 

--- a/traverseService.py
+++ b/traverseService.py
@@ -387,7 +387,7 @@ def getSchemaDetailsLocal(SchemaType, SchemaURI):
             return getSchemaDetailsLocal(SchemaType, Alias + SchemaSuffix)
         else:
             traverseLogger.error(
-                "File not found in {} for {}: ".format(SchemaLocation, pout))
+                "Schema file {} not found in {}".format(pout, SchemaLocation))
             if Alias == '$metadata':
                 traverseLogger.error(
                     "If $metadata cannot be found, Annotations may be unverifiable")


### PR DESCRIPTION
Report improvements:
- formatted array member properties to use standard notation (`RegistryEntries.Attributes[279].Value[4].ValueName` vs. `RegistryEntries.Attributes.Value.ValueName#4#279`)
- property names in error messages consistent with how they are shown in the resource report tables
- fixed formatting of error messages to remove extraneous text before the property name that had the error

Fixes #150 

Before:

![screen shot 2018-02-12 at 4 11 10 pm](https://user-images.githubusercontent.com/3341721/36122556-683c5f02-100f-11e8-86e4-4a2a9e70ddb9.png)
![screen shot 2018-02-12 at 3 56 17 pm](https://user-images.githubusercontent.com/3341721/36122438-ebad582e-100e-11e8-918a-153e6fea7238.png)

![screen shot 2018-02-12 at 4 03 44 pm](https://user-images.githubusercontent.com/3341721/36122472-11e18114-100f-11e8-8e71-d61193e9c1ce.png)


After:

![screen shot 2018-02-12 at 4 11 10 pm](https://user-images.githubusercontent.com/3341721/36122562-74290d7e-100f-11e8-8a43-f1eb6f9bb6d0.png)
![screen shot 2018-02-12 at 4 01 40 pm](https://user-images.githubusercontent.com/3341721/36122452-fdc29d3a-100e-11e8-95e2-57cfc2a02907.png)

![screen shot 2018-02-12 at 4 04 14 pm](https://user-images.githubusercontent.com/3341721/36122489-1cdc6ab6-100f-11e8-85b5-d96384f697e4.png)

