### PR TITLE
Add collection sample notation to the resource uri report headers

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1063,7 +1063,13 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
         rsvLogger.removeHandler(errh)  # Printout FORMAT
         return False, counts, results, None, None
     counts['passGet'] += 1
-    results[uriName] = (str(URI) + ' (response time: {}s)'.format(propResourceObj.rtime), success, counts, messages, errorMessages, propResourceObj.context, propResourceObj.typeobj.fulltype)
+
+    # if URI was sampled, get the notation text from rst.uri_sample_map
+    sample_string = rst.uri_sample_map.get(URI)
+    sample_string = sample_string + ', ' if sample_string is not None else ''
+
+    results[uriName] = (str(URI) + ' ({}response time: {}s)'.format(sample_string, propResourceObj.rtime),
+                        success, counts, messages, errorMessages, propResourceObj.context, propResourceObj.typeobj.fulltype)
 
     # If this is an AttributeRegistry, load it for later use
     if isinstance(propResourceObj.jsondata, dict):

--- a/traverseService.py
+++ b/traverseService.py
@@ -989,15 +989,17 @@ def enumerate_collection(items, cTypeName, linklimits, sample_size):
             if linklimits[cTypeName] < len(items):
                 uri = items[i].get('@odata.id')
                 if uri is not None:
-                    uri_sample_map[uri] = 'Collection limit {} of {}'.format(limit, len(items))
+                    uri_sample_map[uri] = 'Collection limit {} of {}'.format(i + 1, limit)
             yield i, items[i]
     elif 0 < sample_size < len(items):
         # "sample size" case
         traverseLogger.debug('Limiting "{}" to sample of {} links'.format(cTypeName, sample_size))
+        sample = 0
         for i in sorted(random.sample(range(len(items)), sample_size)):
+            sample += 1
             uri = items[i].get('@odata.id')
             if uri is not None:
-                uri_sample_map[uri] = 'Collection sample {} of {}'.format(sample_size, len(items))
+                uri_sample_map[uri] = 'Collection sample {} of {}'.format(sample, sample_size)
             yield i, items[i]
     else:
         # "all" case

--- a/traverseService.py
+++ b/traverseService.py
@@ -30,7 +30,11 @@ proxies = {'http': None, 'https': None}
 
 currentSession = rfSession()
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
- 
+
+# dictionary to hold sampling notation strings for URIs
+uri_sample_map = dict()
+
+
 def getLogger():
     """
     Grab logger for tools that might use this lib
@@ -982,11 +986,18 @@ def enumerate_collection(items, cTypeName, linklimits, sample_size):
         limit = min(linklimits[cTypeName], len(items))
         traverseLogger.debug('Limiting "{}" to first {} links'.format(cTypeName, limit))
         for i in range(limit):
+            if linklimits[cTypeName] < len(items):
+                uri = items[i].get('@odata.id')
+                if uri is not None:
+                    uri_sample_map[uri] = 'Collection limit {} of {}'.format(limit, len(items))
             yield i, items[i]
     elif 0 < sample_size < len(items):
         # "sample size" case
         traverseLogger.debug('Limiting "{}" to sample of {} links'.format(cTypeName, sample_size))
         for i in sorted(random.sample(range(len(items)), sample_size)):
+            uri = items[i].get('@odata.id')
+            if uri is not None:
+                uri_sample_map[uri] = 'Collection sample {} of {}'.format(sample_size, len(items))
             yield i, items[i]
     else:
         # "all" case


### PR DESCRIPTION
Adds collection sample notation to the resource URI report headers.

Before:

![screen shot 2018-02-15 at 5 29 19 pm](https://user-images.githubusercontent.com/3341721/36286560-f668f2be-1275-11e8-9304-72024d615d37.png)


After:

![screen shot 2018-02-15 at 5 33 06 pm](https://user-images.githubusercontent.com/3341721/36286677-5e16d458-1276-11e8-8296-493545d31401.png)


Fixes #152 