### PR TITLE
Enhance validation of Actions block

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -54,7 +54,8 @@ def validateActions(name, val, propTypeObj, payloadType):
             # validate target
             target = actionDecoded.get('target')
             if target is None:
-                rsvLogger.warn('{}: target for action is missing'.format(name + '.' + k))
+                actPass = False
+                rsvLogger.error('{}: target for action is missing'.format(name + '.' + k))
             elif not isinstance(target, str):
                 actPass = False
                 rsvLogger.error('{}: target for action is malformed; expected string, got {}'

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -49,24 +49,28 @@ def validateActions(name, val, propTypeObj, payloadType):
     # (should check for viable parameters)
     for k in actionsDict:
         actionDecoded = val.get(k, 'n/a')
-        actPass = False
+        actPass = True
         if actionDecoded != 'n/a':
+            # validate target
             target = actionDecoded.get('target')
-            if target is not None and isinstance(target, str):
-                actPass = True
-            elif target is None:
+            if target is None:
                 rsvLogger.warn('{}: target for action is missing'.format(name + '.' + k))
-                actPass = True
-            else:
+            elif not isinstance(target, str):
+                actPass = False
                 rsvLogger.error('{}: target for action is malformed; expected string, got {}'
-                                .format(name + '.' + k, str(type(target))))
+                                .format(name + '.' + k, str(type(target)).strip('<>')))
+            # check for unexpected properties
+            for prop in actionDecoded:
+                if prop not in ['target', '@Redfish.ActionInfo'] and '@Redfish.AllowableValues' not in prop:
+                    actPass = False
+                    rsvLogger.error('{}: Property "{}" is not allowed in actions property. Allowed properties are "{}", "{}" and "{}"'
+                                    .format(name + '.' + k, prop, 'target', '@Redfish.ActionInfo', '*@Redfish.AllowableValues'))
         else:
             # <Annotation Term="Redfish.Required"/>
             if actionsDict[k].find('annotation', {'term': 'Redfish.Required'}):
-
+                actPass = False
                 rsvLogger.error('{}: action not found, is mandatory'.format(name + '.' + k))
             else:
-                actPass = True
                 rsvLogger.warn('{}: action not found, is not mandatory'.format(name + '.' + k))
         actionMessages[name + '.' + k] = (
                     'Action', '-',

--- a/traverseService.py
+++ b/traverseService.py
@@ -1080,6 +1080,22 @@ def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=N
                                          .format(insideItem, cType, cSchema))
                     linkList[prefix + str(item) + '.' + getType(propDict['attrs']['Name'])] = (
                         uriItem.get('@odata.id'), autoExpand, cType, cSchema, uriItem)
+            elif item == 'Actions':
+                # special handling for @Redfish.ActionInfo payload annotations
+                insideItem = jsonData.get(item)
+                if isinstance(insideItem, dict):
+                    cType = 'ActionInfo.ActionInfo'
+                    autoExpand = propDict.get('OData.AutoExpand', None) is not None or \
+                                 propDict.get('OData.AutoExpand'.lower(), None) is not None
+                    cSchema = refDict.get(getNamespace(cType), (None, None))[1]
+                    for k, v in insideItem.items():
+                        uri = v.get('@Redfish.ActionInfo')
+                        if isinstance(uri, str):
+                            uriItem = {'@odata.id': uri}
+                            traverseLogger.debug('{}{}: @Redfish.ActionInfo annotation uri = {}'.format(item, k, uri))
+                            linkList[prefix + str(item) + k + '.' + cType] = (
+                                uriItem.get('@odata.id'), autoExpand, cType, cSchema, uriItem)
+
         for propx in propList:
             propDict = propx.propDict
             key = propx.name


### PR DESCRIPTION
Made the following updates:
- If an `@Redfish.ActionInfo` payload annotation is present in an Actions block, add the referenced URI to the set of resources to be validated. So these resources now get validated just like other resources.
- Validate that the only allowed properties within the actions property are `target`, `@Redfish.ActionInfo`, and `*@Redfish.AllowableValues`.
- If the `target` property is missing, an error is emitted (per recent spec clarification)

Fixes #182 