### PR TITLE
Add new $metadata validation section to HTML report

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1451,7 +1451,7 @@ def main(argv=None):
         '</th></tr>' \
         ''
 
-    htmlStr = ''
+    htmlStr = rst.metadata.to_html()
 
     rsvLogger.info(len(results))
     for cnt, item in enumerate(results):

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -999,7 +999,9 @@ def checkPayloadConformance(uri, decoded, ParentItem=None):
                 paramPass = re.match('(\/.*)+#([a-zA-Z0-9_.-]*\.)[a-zA-Z0-9_.-]*', decoded[key]) is not None or\
                     re.match('(\/.*)+#(\/.*)+[/]$entity', decoded[key]) is not None
             # add the namespace to the set of namespaces referenced by this service
-            rst.metadata.add_service_namespace(rst.getNamespace(decoded[key]))
+            ns = rst.getNamespace(decoded[key])
+            if '/' not in ns and not ns.endswith('$entity'):
+                rst.metadata.add_service_namespace(ns)
         elif key == '@odata.type':
             paramPass = isinstance(decoded[key], str)
             if paramPass:
@@ -1388,7 +1390,7 @@ def main(argv=None):
     if 'Single' in pmode:
         success, counts, results, xlinks, topobj = validateSingleURI(ppath, 'Target', expectedJson=jsonData)
     elif 'Tree' in pmode:
-       success, counts, results, xlinks, topobj = validateURITree(ppath, 'Target', expectedJson=jsonData)
+        success, counts, results, xlinks, topobj = validateURITree(ppath, 'Target', expectedJson=jsonData)
     else:
         success, counts, results, xlinks, topobj = validateURITree('/redfish/v1', 'ServiceRoot', expectedJson=jsonData)
 
@@ -1452,6 +1454,7 @@ def main(argv=None):
         ''
 
     htmlStr = rst.metadata.to_html()
+    finalCounts.update(rst.metadata.get_counter())
 
     rsvLogger.info(len(results))
     for cnt, item in enumerate(results):

--- a/metadata.py
+++ b/metadata.py
@@ -4,20 +4,43 @@
 
 import traverseService as rst
 
+EDM_NAMESPACE = "http://docs.oasis-open.org/odata/ns/edm"
+EDMX_NAMESPACE = "http://docs.oasis-open.org/odata/ns/edmx"
+EDM_TAGS = ['Action', 'Annotation', 'Collection', 'ComplexType', 'EntityContainer', 'EntityType', 'EnumType', 'Key',
+            'Member', 'NavigationProperty', 'Parameter', 'Property', 'PropertyRef', 'PropertyValue', 'Record',
+            'Schema', 'Singleton', 'Term', 'TypeDefinition']
+EDMX_TAGS = ['DataServices', 'Edmx', 'Include', 'Reference']
+
+
+def bad_edm_tags(tag):
+    return tag.namespace == EDM_NAMESPACE and tag.name not in EDM_TAGS
+
+
+def bad_edmx_tags(tag):
+    return tag.namespace == EDMX_NAMESPACE and tag.name not in EDMX_TAGS
+
+
+def other_ns_tags(tag):
+    return tag.namespace != EDM_NAMESPACE and tag.namespace != EDMX_NAMESPACE
+
 
 class Metadata(object):
     metadata_uri = '/redfish/v1/$metadata'
     schema_type = '$metadata'
 
     def __init__(self, logger):
+        self.soup = None
         self.service_refs = dict()
         self.metadata_namespaces = set()
         self.service_namespaces = set()
+        self.bad_tags = dict()
+        self.bad_tag_ns = dict()
         self.logger = logger
         self.redfish_extensions_alias_ok = False
 
         success, soup, uri = rst.getSchemaDetails(Metadata.schema_type, Metadata.metadata_uri)
         if success:
+            self.soup = soup
             self.service_refs = rst.getReferenceDetails(soup, name=Metadata.schema_type)
             self.metadata_namespaces = {k for k in self.service_refs.keys()}
             logger.debug('Metadata: uri = {}'.format(uri))
@@ -28,8 +51,14 @@ class Metadata(object):
             if ref is not None and ref[0] == 'RedfishExtensions.v1_0_0':
                 self.redfish_extensions_alias_ok = True
             logger.debug('Metadata: redfish_extensions_alias_ok = {}'.format(self.redfish_extensions_alias_ok))
+            self.check_tags(soup)
+            logger.debug('Metadata: bad_tags = {}'.format(self.bad_tags))
+            logger.debug('Metadata: bad_tag_ns = {}'.format(self.bad_tag_ns))
         else:
             logger.debug('Metadata: getSchemaDetails() did not return success')
+
+    def get_soup(self):
+        return self.soup
 
     def get_service_refs(self):
         return self.service_refs
@@ -55,3 +84,23 @@ class Metadata(object):
 
     def redfish_extensions_alias_ok(self):
         return self.redfish_extensions_alias_ok
+
+    def check_tags(self, soup):
+        try:
+            for tag in soup.find_all(bad_edm_tags):
+                tag_name = tag.name if tag.prefix is None else tag.prefix + ':' + tag.name
+                self.bad_tags[tag_name] = self.bad_tags.get(tag_name, 0) + 1
+            for tag in soup.find_all(bad_edmx_tags):
+                tag_name = tag.name if tag.prefix is None else tag.prefix + ':' + tag.name
+                self.bad_tags[tag_name] = self.bad_tags.get(tag_name, 0) + 1
+            for tag in soup.find_all(other_ns_tags):
+                tag_name = tag.name if tag.prefix is None else tag.prefix + ':' + tag.name
+                tag_ns = 'xmlns{}="{}"'.format(':' + tag.prefix if tag.prefix is not None else '', tag.namespace)
+                tag_name = tag_name + ' ' + tag_ns
+                self.bad_tag_ns[tag_name] = self.bad_tag_ns.get(tag_name, 0) + 1
+            # TODO: add check for misspelled/missing attributes:
+            #     <edmx:Reference Uri="/redfish/v1/Schemas/ServiceRoot_v1.xml">
+            #     <edmx:Include Namespace="ServiceRoot.v1_0_0"/>
+            #     <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+        except Exception as e:
+            self.logger.warning('Error parsing document with BeautifulSoup4, error: {}'.format(e))

--- a/metadata.py
+++ b/metadata.py
@@ -1,0 +1,57 @@
+# Copyright Notice:
+# Copyright 2018 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Service-Validator/blob/master/LICENSE.md
+
+import traverseService as rst
+
+
+class Metadata(object):
+    metadata_uri = '/redfish/v1/$metadata'
+    schema_type = '$metadata'
+
+    def __init__(self, logger):
+        self.service_refs = dict()
+        self.metadata_namespaces = set()
+        self.service_namespaces = set()
+        self.logger = logger
+        self.redfish_extensions_alias_ok = False
+
+        success, soup, uri = rst.getSchemaDetails(Metadata.schema_type, Metadata.metadata_uri)
+        if success:
+            self.service_refs = rst.getReferenceDetails(soup, name=Metadata.schema_type)
+            self.metadata_namespaces = {k for k in self.service_refs.keys()}
+            logger.debug('Metadata: uri = {}'.format(uri))
+            # logger.debug('Metadata: service_refs: {} = {}'.format(type(self.service_refs), self.service_refs))
+            logger.debug('Metadata: metadata_namespaces: {} = {}'
+                         .format(type(self.metadata_namespaces), self.metadata_namespaces))
+            ref = self.service_refs.get('Redfish')
+            if ref is not None and ref[0] == 'RedfishExtensions.v1_0_0':
+                self.redfish_extensions_alias_ok = True
+            logger.debug('Metadata: redfish_extensions_alias_ok = {}'.format(self.redfish_extensions_alias_ok))
+        else:
+            logger.debug('Metadata: getSchemaDetails() did not return success')
+
+    def get_service_refs(self):
+        return self.service_refs
+
+    def get_metadata_namespaces(self):
+        return self.metadata_namespaces
+
+    def get_service_namespaces(self):
+        return self.service_namespaces
+
+    def add_service_namespace(self, namespace):
+        self.service_namespaces.add(namespace)
+
+    def get_missing_namespaces(self):
+        return self.service_namespaces - self.metadata_namespaces
+
+    def get_schema_uri(self, namespace):
+        ref = self.service_refs.get(namespace)
+        if ref is not None:
+            return ref[1]
+        else:
+            return None
+
+    def redfish_extensions_alias_ok(self):
+        return self.redfish_extensions_alias_ok

--- a/metadata.py
+++ b/metadata.py
@@ -42,12 +42,12 @@ def format_tag_string(tag):
     return (tag_name + ' ' + tag_attr).strip()
 
 
-def tag_table_html(tags):
-    html_str = '<tr><td class="fail log"><ul>'
-    for tag in tags:
+def tag_list_html(tags_dict):
+    html_str = '<ul>'
+    for tag in tags_dict:
         html_str += '<li>{} {}</li>' \
-            .format(tag, '(' + str(tags[tag]) + ' occurrences)' if tags[tag] > 1 else '')
-    html_str += '</ul></td></tr>'
+            .format(tag, '(' + str(tags_dict[tag]) + ' occurrences)' if tags_dict[tag] > 1 else '')
+    html_str += '</ul>'
     return html_str
 
 
@@ -190,30 +190,33 @@ class Metadata(object):
 
         if self.success_get and not errors_found:
             html_str += '<tr><td class="pass log">Validation successful</td></tr>'
+        elif not self.success_get:
+            html_str += '<tr><td class="fail log">ERROR - Unable to retrieve $metadata resource at {}</td></tr>'\
+                .format(Metadata.metadata_uri)
         else:
-            if not self.success_get:
-                html_str += '<tr><td class="fail log">ERROR - Unable to retrieve $metadata resource at {}</td></tr>'\
-                    .format(Metadata.metadata_uri)
-            elif not self.redfish_extensions_alias_ok:
+            if not self.redfish_extensions_alias_ok:
                 html_str += '<tr><td class="fail log">ERROR - $metadata does not include the required "RedfishExtensions.v1_0_0" namespace with an alias of "Redfish"</td></tr>'
             if len(self.get_missing_namespaces()) > 0:
-                html_str += '<tr><td class="fail log">ERROR - The following namespaces are referenced by the service, but are not included in $metadata:</td></tr>'
-                html_str += '<tr><td class="fail log"><ul>'
+                html_str += '<tr><td class="fail log">ERROR - The following namespaces are referenced by the service, but are not included in $metadata:<ul>'
                 for ns in self.get_missing_namespaces():
                     html_str += '<li>{}</li>'.format(ns)
                 html_str += '</ul></td></tr>'
             if len(self.bad_tags) > 0:
-                html_str += '<tr><td class="fail log">ERROR - The following tag names in $metadata are unrecognized (check spelling or case):</td></tr>'
-                html_str += tag_table_html(self.bad_tags)
+                html_str += '<tr><td class="fail log">ERROR - The following tag names in $metadata are unrecognized (check spelling or case):'
+                html_str += tag_list_html(self.bad_tags)
+                html_str += '</td></tr>'
             if len(self.refs_missing_uri) > 0:
-                html_str += '<tr><td class="fail log">ERROR - The following Reference tags in $metadata are missing the expected Uri attribute (check spelling or case):</td></tr>'
-                html_str += tag_table_html(self.refs_missing_uri)
+                html_str += '<tr><td class="fail log">ERROR - The following Reference tags in $metadata are missing the expected Uri attribute (check spelling or case):'
+                html_str += tag_list_html(self.refs_missing_uri)
+                html_str += '</td></tr>'
             if len(self.includes_missing_ns) > 0:
-                html_str += '<tr><td class="fail log">ERROR - The following Include tags in $metadata are missing the expected Namespace attribute (check spelling or case):</td></tr>'
-                html_str += tag_table_html(self.includes_missing_ns)
+                html_str += '<tr><td class="fail log">ERROR - The following Include tags in $metadata are missing the expected Namespace attribute (check spelling or case):'
+                html_str += tag_list_html(self.includes_missing_ns)
+                html_str += '</td></tr>'
             if len(self.bad_tag_ns) > 0:
-                html_str += '<tr><td class="fail log">ERROR - The following tags in $metadata have an unexpected namespace:</td></tr>'
-                html_str += tag_table_html(self.bad_tag_ns)
+                html_str += '<tr><td class="fail log">ERROR - The following tags in $metadata have an unexpected namespace:'
+                html_str += tag_list_html(self.bad_tag_ns)
+                html_str += '</td></tr>'
         html_str += '</table>'
 
         return html_str

--- a/traverseService.py
+++ b/traverseService.py
@@ -332,6 +332,10 @@ def getSchemaDetails(SchemaType, SchemaURI):
                 else:
                     traverseLogger.error(
                         "SchemaURI missing reference link {} inside {}".format(frag, SchemaURI))
+                    # error reported; assume likely schema uri to allow continued validation
+                    uri = 'http://redfish.dmtf.org/schemas/v1/{}_v1.xml'.format(frag)
+                    traverseLogger.info("Continue assuming schema URI for {} is {}".format(SchemaType, uri))
+                    return getSchemaDetails(SchemaType, uri)
             else:
                 return True, soup, SchemaURI
         if isNonService(SchemaURI) and ServiceOnly:

--- a/traverseService.py
+++ b/traverseService.py
@@ -33,6 +33,9 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 # dictionary to hold sampling notation strings for URIs
 uri_sample_map = dict()
 
+# holds instance of Metadata class for $metadata processing and validation
+metadata = None
+
 
 def getLogger():
     """
@@ -273,11 +276,15 @@ def callResourceURI(URILink):
 # note: Use some sort of re expression to parse SchemaType
 # ex: #Power.1.1.1.Power , #Power.v1_0_0.Power
 def getNamespace(string):
-    return string.replace('#', '').rsplit('.', 1)[0]
+    if '#' in string:
+        string = string.rsplit('#', 1)[1]
+    return string.rsplit('.', 1)[0]
 
 
 def getType(string):
-    return string.replace('#', '').rsplit('.', 1)[-1]
+    if '#' in string:
+        string = string.rsplit('#', 1)[1]
+    return string.rsplit('.', 1)[-1]
 
 
 @lru_cache(maxsize=64)
@@ -604,13 +611,11 @@ class ResourceObj:
 
         self.additionalList = []
         self.initiated = True
-        idtag = (fullType, self.context)  # 🔫
+        idtag = (fullType, self.context)
 
-        serviceRefs = None
-        successService, serviceSchemaSoup, SchemaServiceURI = getSchemaDetails(
-            '$metadata', '/redfish/v1/$metadata')
-        if successService:
-            serviceRefs = getReferenceDetails(serviceSchemaSoup, name=SchemaServiceURI)
+        serviceRefs = metadata.get_service_refs()
+        serviceSchemaSoup = metadata.get_soup()
+        if serviceSchemaSoup is not None:
             successService, additionalProps = getAnnotations(
                 serviceSchemaSoup, serviceRefs, self.jsondata)
             for prop in additionalProps:
@@ -1125,6 +1130,9 @@ def getAnnotations(soup, refs, decoded, prefix=''):
         if getNamespace(fullItem) not in allowed_annotations:
             traverseLogger.error("getAnnotations: {} is not an allowed annotation namespace, please check spelling/capitalization.".format(fullItem))
             continue
+        else:
+            # add the namespace to the set of namespaces referenced by this service
+            metadata.add_service_namespace(getNamespace(fullItem))
         realType, refLink = refs.get(getNamespace(fullItem), (None, None))
         success, annotationSoup, uri = getSchemaDetails(realType, refLink)
         traverseLogger.debug('{}, {}, {}, {}, {}'.format(


### PR DESCRIPTION
Added new $metadata validation section to HTML report. Also added fix for issue described in #195.

Fixes #185 
Fixes #195 

New $metadata report section (appears at beginning of report) shows $metadata validation errors:

![screen shot 2018-04-12 at 1 08 02 pm](https://user-images.githubusercontent.com/3341721/38696197-1832a14c-3e54-11e8-9472-f1826df7b429.png)

After cleaning up errors:

![screen shot 2018-04-11 at 2 06 42 pm](https://user-images.githubusercontent.com/3341721/38638182-128f3906-3d93-11e8-8702-9e76480af2ef.png)


Regarding the fix for issue #195: If, for example, the AccountService schema reference is missing from the $metadata, you would previously get a result like this:

![screen shot 2018-04-11 at 2 28 34 pm](https://user-images.githubusercontent.com/3341721/38638768-e58abf1e-3d94-11e8-86d8-e6cb60d5a3eb.png)

After the fix, the missing reference is reported, but the correct schema uri is assumed, the schema is fetched and the validation proceeds:

![screen shot 2018-04-11 at 2 29 36 pm](https://user-images.githubusercontent.com/3341721/38638781-ee48e324-3d94-11e8-9b1a-6b87724bd0a0.png)

