### PR TITLE
Avoid "collection" odata term in report; use "array" instead

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -516,7 +516,7 @@ def displayType(propType, propRealType, is_collection=False):
         if propType.startswith('Collection('):
             member_type = propType.replace('Collection(', '').replace(')', '')
             if is_collection:
-                disp_type = 'collection of: {}'.format(member_type.rsplit('.', 1)[-1])
+                disp_type = 'array of: {}'.format(member_type.rsplit('.', 1)[-1])
             else:
                 disp_type = member_type.rsplit('.', 1)[-1]
         else:
@@ -526,7 +526,7 @@ def displayType(propType, propRealType, is_collection=False):
         if propType.startswith('Collection('):
             member_type = propType.replace('Collection(', '').replace(')', '')
             if is_collection:
-                disp_type = 'collection of: {}'.format(member_type.rsplit('.', 1)[-1])
+                disp_type = 'array of: {}'.format(member_type.rsplit('.', 1)[-1])
             else:
                 disp_type = member_type.rsplit('.', 1)[-1]
         else:
@@ -861,7 +861,7 @@ def checkPropertyConformance(soup, PropertyName, PropertyItem, decoded, refs, Pa
         # rs-assumption: check @odata.count property
         # rs-assumption: check @odata.link property
         rsvLogger.info("\tis Collection")
-        resultList[item] = ('Collection, size: ' + str(len(propValue)),
+        resultList[item] = ('Array (size: {})'.format(len(propValue)),
                             displayType(propType, propRealType, is_collection=True),
                             'Yes' if propExists else 'No', '...')
         propValueList = propValue


### PR DESCRIPTION
For properties that are odata Collection types, use the term "array" in the report rather than "collection".

Before:

`Collection, size: 3`

`collection of: IPv4Address`

After:

`Array (size: 3)`

`array of: IPv4Address`

Fixes #192 