### PR TITLE
Avoid exception and better errors in getPropertyDetails and getTypeDetails

### DIFF
--- a/traverseService.py
+++ b/traverseService.py
@@ -987,9 +987,8 @@ def getPropertyDetails(soup, refs, propertyOwner, propertyName, ownerTagType='En
             break
 
         else:
-            traverseLogger.error("type doesn't exist? {}".format(propertyFullType))
-            raise Exception(
-                "getPropertyDetails: problem grabbing type: " + propertyFullType)
+            traverseLogger.error('Type {} not found under namespace {} in schema {}'
+                                 .format(PropertyType, PropertyNamespace, uri))
             break
 
     return propEntry

--- a/traverseService.py
+++ b/traverseService.py
@@ -741,8 +741,14 @@ def getTypeDetails(soup, refs, SchemaAlias, tagType, topVersion=None):
     innerschema = soup.find('Schema', attrs={'Namespace': SchemaNamespace})
 
     if innerschema is None:
-        traverseLogger.error("Got XML, but expected schema doesn't exist...? {}, {}\n... we will be unable to generate properties".format(
-                             SchemaNamespace, SchemaType))
+        uri = metadata.get_schema_uri(SchemaNamespace)
+        if uri is None:
+            if '.' in SchemaNamespace:
+                uri = metadata.get_schema_uri(SchemaNamespace.split('.', 1)[0])
+            else:
+                uri = metadata.get_schema_uri(SchemaType)
+        traverseLogger.error('Schema namespace {} not found in schema file {}. Will not be able to gather type details.'
+                             .format(SchemaNamespace, uri if uri is not None else SchemaType))
         return False, PropertyList, PropertyPattern
 
     element = innerschema.find(tagType, attrs={'Name': SchemaType}, recursive=False)


### PR DESCRIPTION
### Removed the explicit `raise Exception()` in getPropertyDetails() and provided a better error message:

Old:

> ERROR - type doesn't exist? Resource.Location
> ERROR - Something went wrong
> Traceback (most recent call last):
>  File "/Users/bdodd/Development/git/Redfish-Service-Validator/traverseService.py", line 673, in __init__
    soup, refs, propOwner, propChild, tagType, topVersion)
> File "/Users/bdodd/Development/git/Redfish-Service-Validator/traverseService.py", line 992, in getPropertyDetails
    "getPropertyDetails: problem grabbing type: " + propertyFullType)
> Exception: getPropertyDetails: problem grabbing type: Resource.Location
> ERROR - #Chassis.v1_2_0.Chassis:Location :  Could not get details on this property

New:

> ERROR - Type Location not found under namespace Resource in schema http://redfish.dmtf.org/schemas/v1/Resource.xml

### Also updated error message in getTypeDetails() to be succinct (inspired by issue #219):

Old:

> ERROR - Got XML, but expected schema doesn't exist...? ServiceRoot.v1_3_0, ServiceRoot
> ... we will be unable to generate properties

New:

> ERROR - Schema namespace ServiceRoot.v1_3_0 not found in schema file http://redfish.dmtf.org/schemas/v1/ServiceRoot_v1.xml. Will not be able to gather type details.

Fixes #217 
