### PR TITLE
Cleaner log output, repartitioning code for tests, split warn/error

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ A GUI is also available to let a user fill in configuration options using a form
 
     python3 RedfishServiceValidatorGui.py
 
+To run unittests, use the command:
+    
+    python3 -m unittest tests/*.py
+
 ## Execution flow
 
 1. Redfish Service Validator starts with the Service root Resource Schema by querying the service with the service root URI and getting all the device information, the resources supported and their links. Once the response of the Service root query is verified against its schema, the tool traverses through all the collections and Navigation properties returned by the service.

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1142,8 +1142,6 @@ def main(argv=None, direct_parser=None):
     """
     Main program
     """
-
-    print(rsvLogger)
     rsvLogger.info('ok')
     
     if argv is None:

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -12,11 +12,11 @@ from datetime import datetime
 from collections import Counter, OrderedDict
 import logging
 import json
-import html
-import traverseService as rst
+
+from simpletypes import *
 from traverseService import AuthenticationError
-import metadata as md
-import RedfishLogo as logo
+from tohtml import renderHtml, writeHtml
+import traverseService as rst
 
 tool_version = '1.0.8'
 
@@ -570,120 +570,6 @@ def displayValue(val, autoExpandName=None):
     return disp_val
 
 
-def validateDeprecatedEnum(name, val, listEnum):
-    """
-    Validates a DeprecatedEnum
-    """
-    paramPass = True
-    if isinstance(val, list):
-        display_val = []
-        for enumItem in val:
-            display_val.append(dict(enumItem))
-            for k, v in enumItem.items():
-                paramPass = paramPass and str(v) in listEnum
-        if not paramPass:
-            rsvLogger.error("{}: Invalid DeprecatedEnum value '{}' found, expected {}"
-                            .format(str(name), display_val, str(listEnum)))
-    elif isinstance(val, str):
-        paramPass = str(val) in listEnum
-        if not paramPass:
-            rsvLogger.error("{}: Invalid DeprecatedEnum value '{}' found, expected {}"
-                            .format(str(name), val, str(listEnum)))
-    else:
-        rsvLogger.error("{}: Expected list or string value for DeprecatedEnum, got {}".format(str(name), str(type(val)).strip('<>')))
-    return paramPass
-
-
-def validateEnum(name, val, listEnum):
-    paramPass = isinstance(val, str)
-    if paramPass:
-        paramPass = val in listEnum
-        if not paramPass:
-            rsvLogger.error("{}: Invalid Enum value '{}' found, expected {}".format(str(name), val, str(listEnum)))
-    else:
-        rsvLogger.error("{}: Expected string value for Enum, got {}".format(str(name), str(type(val)).strip('<>')))
-    return paramPass
-
-
-def validateString(name, val, pattern=None):
-    """
-    Validates a string, given a value and a pattern
-    """
-    paramPass = isinstance(val, str)
-    if paramPass:
-        if pattern is not None:
-            match = re.fullmatch(pattern, val)
-            paramPass = match is not None
-            if not paramPass:
-                rsvLogger.error("{}: String '{}' does not match pattern '{}'".format(name, str(val), str(pattern)))
-        else:
-            paramPass = True
-    else:
-        rsvLogger.error("{}: Expected string value, got type {}".format(name, str(type(val)).strip('<>')))
-    return paramPass
-
-
-def validateDatetime(name, val):
-    """
-    Validates a Datetime, given a value (pattern predetermined)
-    """
-    paramPass = validateString(name, val, '.*(Z|(\+|-)[0-9][0-9]:[0-9][0-9])')
-    if not paramPass:
-        rsvLogger.error("\t...: Malformed DateTimeOffset")
-    return paramPass
-
-
-def validateGuid(name, val):
-    """
-    Validates a Guid, given a value (pattern predetermined)
-    """
-    paramPass = validateString(name, val, "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
-    if not paramPass:
-        rsvLogger.error("\t...: Malformed Guid")
-    return paramPass
-
-
-def validateInt(name, val, minVal=None, maxVal=None):
-    """
-    Validates a Int, then passes info to validateNumber
-    """
-    if not isinstance(val, int):
-        rsvLogger.error("{}: Expected integer, got type {}".format(name, str(type(val)).strip('<>')))
-        return False
-    else:
-        return validateNumber(name, val, minVal, maxVal)
-
-
-def validateNumber(name, val, minVal=None, maxVal=None):
-    """
-    Validates a Number and its min/max values
-    """
-    paramPass = isinstance(val, (int, float))
-    if paramPass:
-        if minVal is not None:
-            paramPass = paramPass and minVal <= val
-            if not paramPass:
-                rsvLogger.error("{}: Value out of assigned min range, {} < {}".format(name, str(val), str(minVal)))
-        if maxVal is not None:
-            paramPass = paramPass and maxVal >= val
-            if not paramPass:
-                rsvLogger.error("{}: Value out of assigned max range, {} > {}".format(name, str(val), str(maxVal)))
-    else:
-        rsvLogger.error("{}: Expected integer or float, got type {}".format(name, str(type(val)).strip('<>')))
-    return paramPass
-
-
-def validatePrimitive(name, val):
-    """
-    Validates a Primitive
-    """
-    if isinstance(val, (int, float, str, bool)):
-        return True
-    else:
-        rsvLogger.error("{}: Expected primitive type, got type {}".format(name, str(type(val)).strip('<>')))
-        return False
-
-
 def loadAttributeRegDict(odata_type, json_data):
     """
     Load the attribute registry from the json payload into a dictionary and store it in global attributeRegistries dict
@@ -1062,6 +948,9 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
     messages = OrderedDict()
     success = True
 
+    results[uriName] = {'uri':URI, 'success':False, 'counts':counts, 'messages':messages, 'errors':errorMessages,\
+            'rtime':'', 'context':'', 'fulltype':''}
+
     # check for @odata mandatory stuff
     # check for version numbering problems
     # check id if its the same as URI
@@ -1093,9 +982,6 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
             uriName, URI, expectedType, expectedSchema, expectedJson, parent)
         if not propResourceObj.initiated:
             counts['problemResource'] += 1
-            success = False
-            results[uriName] = (URI, success, counts, messages,
-                                errorMessages, None, None)
             rsvLogger.removeHandler(errh)  # Printout FORMAT
             return False, counts, results, None, None
     except AuthenticationError as e:
@@ -1103,9 +989,6 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
     except Exception as e:
         rsvLogger.exception("")  # Printout FORMAT
         counts['exceptionResource'] += 1
-        success = False
-        results[uriName] = (URI, success, counts, messages,
-                            errorMessages, None, None)
         rsvLogger.removeHandler(errh)  # Printout FORMAT
         return False, counts, results, None, None
     counts['passGet'] += 1
@@ -1114,8 +997,11 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
     sample_string = rst.uri_sample_map.get(URI)
     sample_string = sample_string + ', ' if sample_string is not None else ''
 
-    results[uriName] = (str(URI) + ' ({}response time: {}s)'.format(sample_string, propResourceObj.rtime),
-                        success, counts, messages, errorMessages, propResourceObj.context, propResourceObj.typeobj.fulltype)
+    results[uriName]['uri'] = (str(URI) + ' ({}response time: {}s)'.format(sample_string, propResourceObj.rtime))
+    results[uriName]['rtime'] = propResourceObj.rtime
+    results[uriName]['context'] = propResourceObj.context
+    results[uriName]['fulltype'] = propResourceObj.typeobj.fulltype
+    results[uriName]['success'] = True
 
     # If this is an AttributeRegistry, load it for later use
     if isinstance(propResourceObj.jsondata, dict):
@@ -1250,31 +1136,39 @@ def validateURITree(URI, uriName, expectedType=None, expectedSchema=None, expect
 
     return validateSuccess, counts, results, refLinks, thisobj
 
-argparse2configparser = {
-        'user': 'username', 'nochkcert': '!certificatecheck', 'ca_bundle': 'certificatebundle', 'schemamode': 'schemamode',
-        'suffix': 'schemasuffix', 'schemadir': 'metadatafilepath', 'nossl': '!usessl', 'timeout': 'timeout', 'service': 'servicemode',
-        'http_proxy': 'httpproxy', 'localonly': 'localonlymode', 'https_proxy': 'httpsproxy', 'passwd': 'password',
-        'ip': 'targetip', 'logdir': 'logpath', 'desc': 'systeminfo', 'authtype': 'authtype',
-        'payload': 'payloadmode+payloadfilepath', 'cache': 'cachemode+cachefilepath', 'token': 'token',
-        'linklimit': 'linklimit', 'sample': 'sample'}
-
 validatorconfig = {'payloadmode': 'Default', 'payloadfilepath': None, 'logpath': './logs'}
 
-def main(configpsr=None):
-    # this should be surface level, does no execution (should maybe move html rendering to its own function
-    # Only worry about configuring, executing and exiting circumstances, printout setup
-    # info: config information (without password), time started/finished, individual problems, pass/fail
-    # error: config is not good (catch, success), traverse is not good (should never happen)
-    # warn: what's missing that we can work around (local files?)
+def main(argv=None, direct_parser=None):
+    """
+    Main program
+    """
+
+    print(rsvLogger)
+    rsvLogger.info('ok')
+    
+    if argv is None:
+        argv = sys.argv
 
     argget = argparse.ArgumentParser(description='tool to test a service against a collection of Schema')
+    
+    # config
     argget.add_argument('-c', '--config', type=str, help='config file (overrides other params)')
+
+    # tool
+    argget.add_argument('--schemadir', type=str, default='./SchemaFiles/metadata', help='directory for local schema files')
+    argget.add_argument('--desc', type=str, default='No desc', help='sysdescription for identifying logs')
+    argget.add_argument('--logdir', type=str, default='./logs', help='directory for log files')
+    argget.add_argument('--payload', type=str, help='mode to validate payloads [Tree, Single, SingleFile, TreeFile] followed by resource/filepath', nargs=2)
+    argget.add_argument('--sample', type=int, default=0, help='sample this number of members from large collections for validation; default is to validate all members')
+    argget.add_argument('--linklimit', type=str, help='Limit the amount of links in collections, formatted TypeName:## TypeName:## ..., default LogEntry:20 ', nargs='*')
+    argget.add_argument('-v', action='store_true', help='verbose log output to stdout')
+    argget.add_argument('--debug_logging', action="store_const", const=logging.DEBUG, default=logging.INFO,
+            help='Output debug statements to text log, otherwise it only uses INFO')
+
+    # service
     argget.add_argument('-i', '--ip', type=str, help='ip to test on [host:port]')
     argget.add_argument('-u', '--user', default='', type=str, help='user for basic auth')
     argget.add_argument('-p', '--passwd', default='', type=str, help='pass for basic auth')
-    argget.add_argument('--desc', type=str, default='No desc', help='sysdescription for identifying logs')
-    argget.add_argument('--schemadir', type=str, default='./SchemaFiles/metadata', help='directory for local schema files')
-    argget.add_argument('--logdir', type=str, default='./logs', help='directory for log files')
     argget.add_argument('--timeout', type=int, default=30, help='requests timeout in seconds')
     argget.add_argument('--nochkcert', action='store_true', help='ignore check for certificate')
     argget.add_argument('--nossl', action='store_true', help='use http instead of https')
@@ -1286,86 +1180,39 @@ def main(configpsr=None):
     argget.add_argument('--token', default="", type=str, help='bearer token for authtype Token')
     argget.add_argument('--http_proxy', type=str, default='', help='URL for the HTTP proxy')
     argget.add_argument('--https_proxy', type=str, default='', help='URL for the HTTPS proxy')
-    argget.add_argument('-v', action='store_true', help='verbose log output to stdout')
-    argget.add_argument('--payload', type=str, help='mode to validate payloads [Tree, Single, SingleFile, TreeFile] followed by resource/filepath', nargs=2)
     argget.add_argument('--cache', type=str, help='cache mode [Off, Fallback, Prefer] followed by directory', nargs=2)
-    argget.add_argument('--linklimit', type=str, help='Limit the amount of links in collections, formatted TypeName:## TypeName:## ..., default LogEntry:20 ', nargs='*')
-    argget.add_argument('--sample', type=int, default=0, help='sample this number of members from large collections for validation; default is to validate all members')
-    argget.add_argument('--debug_logging', action="store_const", const=logging.DEBUG, default=logging.INFO,
-            help='Output debug statements to text log, otherwise it only uses INFO')
-
 
     args = argget.parse_args()
+    
+    # clear cache from any other runs
+    rst.callResourceURI.cache_clear()
+    rst.getSchemaDetails.cache_clear()
+
+    # set up config (which creates service)
+    if direct_parser is not None:
+        try:
+            cdict = rst.convertConfigParserToDict(direct_parser)
+            rst.setConfig(cdict)
+        except Exception as ex:
+            rsvLogger.exception("Something went wrong")  # Printout FORMAT
+            return 1, None, 'Config Parser Exception'
+    elif args.config is None and args.ip is None:
+        rsvLogger.info('No ip or config specified.')
+        argget.print_help()
+        return 1, None, 'Config Incomplete'
+    else:
+        try:
+            rst.setByArgparse(args)
+        except Exception as ex:
+            rsvLogger.exception("Something went wrong")  # Printout FORMAT
+            return 1, None, 'Config Exception'
 
 
-    if args.v:
-        rst.ch.setLevel(logging.DEBUG)
-    cdict = {}
-    try:
-        if (args.config is not None) or (configpsr is not None):
-            if configpsr is None:
-                # Configuration not provided; read in the config file
-                configpsr = configparser.ConfigParser()
-                configpsr.read(args.config)
-            for x in configpsr:
-                for y in configpsr[x]:
-                    val = configpsr[x][y]
-                    if y not in rst.configset.keys() and x not in ['Information', 'Validator']:
-                        rsvLogger.error('Config option {} in {} unsupported!'.format(y, x))
-                    if val in ['', None]:
-                        continue
-                    if val.isdigit():
-                        val = int(val)
-                    elif y == 'linklimit':
-                        val = re.findall('[A-Za-z_]+:[0-9]+', val)
-                    elif str(val).lower() in ['on', 'true', 'yes']:
-                        val = True
-                    elif str(val).lower() in ['off', 'false', 'no']:
-                        val = False
-                    cdict[y] = val
-        elif args.ip is not None:
-            for param in args.__dict__:
-                if param in argparse2configparser:
-                    if isinstance(args.__dict__[param], list):
-                        for cnt, item in enumerate(argparse2configparser[param].split('+')):
-                            cdict[item] = args.__dict__[param][cnt]
-                    elif '+' not in argparse2configparser[param]:
-                        if '!' in argparse2configparser[param]:
-                            cdict[argparse2configparser[param].replace('!','')] = not args.__dict__[param]
-                        else:
-                            cdict[argparse2configparser[param]] = args.__dict__[param]
-                else:
-                    cdict[param] = args.__dict__[param]
-        else:
-            rsvLogger.info('No ip or config specified.')
-            argget.print_help()
-            return 1, None, 'No configuration given'
-        # Send config only with keys supported by program
-        linklimitdict = {}
-        if cdict.get('linklimit') is not None:
-            for item in cdict.get('linklimit'):
-                if re.match('[A-Za-z_]+:[0-9]+', item) is not None:
-                    typename, count = tuple(item.split(':')[:2])
-                    if typename not in linklimitdict:
-                        linklimitdict[typename] = int(count)
-                    else:
-                        rsvLogger.error('Limit already exists for {}'.format(typename))
-        cdict['linklimit'] = linklimitdict
-
-        rst.setConfig({key: cdict[key] for key in cdict.keys() if key in rst.configset.keys()})
-
-    except Exception as ex:
-        rsvLogger.exception("Something went wrong")  # Printout FORMAT
-        return 1, None, 'Unexpected exception while parsing inputs'
-
-    config_str = ""
-    for cnt, item in enumerate(sorted(list(cdict.keys() - set(['systeminfo', 'configuri', 'targetip', 'configset', 'password', 'description']))), 1):
-        config_str += "{}: {},  ".format(str(item), str(cdict[item] if cdict[item] != '' else 'None'))
-        if cnt % 6 == 0:
-            config_str += '\n'
-
-    sysDescription, ConfigURI = (cdict['systeminfo'], rst.config['configuri'])
-    logpath = cdict['logpath']
+    currentService = rst.currentService
+    metadata = rst.metadata
+    config = rst.config
+    sysDescription, ConfigURI = (config['systeminfo'], config['targetip'])
+    logpath = config['logpath']
 
     # Logging config
     startTick = datetime.now()
@@ -1376,16 +1223,19 @@ def main(configpsr=None):
     fh.setLevel(args.debug_logging)
     fh.setFormatter(fmt)
     rsvLogger.addHandler(fh)  # Printout FORMAT
+
+    # start printing
     rsvLogger.info('ConfigURI: ' + ConfigURI)
     rsvLogger.info('System Info: ' + sysDescription)  # Printout FORMAT
-    rsvLogger.info(config_str)
+    rsvLogger.info(rst.configToStr())
     rsvLogger.info('Start time: ' + startTick.strftime('%x - %X'))  # Printout FORMAT
 
     # Start main
     status_code = 1
     jsonData = None
-    
-    pmode, ppath = cdict.get('payloadmode'), cdict.get('payloadfilepath')
+   
+    # Determine runner
+    pmode, ppath = config.get('payloadmode'), config.get('payloadfilepath')
     if pmode not in ['Tree', 'Single', 'SingleFile', 'TreeFile', 'Default']:
         pmode = 'Default'
         rsvLogger.error('PayloadMode or path invalid, using Default behavior')
@@ -1397,18 +1247,12 @@ def main(configpsr=None):
         else:
             rsvLogger.error('File not found: {}'.format(ppath))
             return 1, None, 'File not found: {}'.format(ppath)
-
-    # start session if using Session auth
-    if rst.currentSession is not None:
-        success = rst.currentSession.startSession()
-        if not success:
-            # terminate program on start session error (error logged in startSession() call above)
-            return 1, None, 'Could not establish a session with the service'
-
-    # read $metadata into Metadata object
-    rst.callResourceURI.cache_clear()
-    rst.getSchemaDetails.cache_clear()
-    rst.metadata = md.Metadata(rsvLogger)
+        # start session if using Session auth
+        if currentService.currentSession is not None:
+            success = currentService.currentSession.startSession()
+            if not success:
+                # terminate program on start session error (error logged in startSession() call above)
+                return 1, None, 'Could not establish a session with the service'
 
     try:
         if 'Single' in pmode:
@@ -1422,6 +1266,8 @@ def main(configpsr=None):
         rsvLogger.error('{}'.format(e))
         return 1, None, 'Failed to authenticate with the service'
 
+    currentService.close()
+
     rsvLogger.debug('Metadata: Namespaces referenced in service: {}'.format(rst.metadata.get_service_namespaces()))
     rsvLogger.debug('Metadata: Namespaces missing from $metadata: {}'.format(rst.metadata.get_missing_namespaces()))
 
@@ -1429,157 +1275,38 @@ def main(configpsr=None):
     nowTick = datetime.now()
     rsvLogger.info('Elapsed time: {}'.format(str(nowTick-startTick).rsplit('.', 1)[0]))  # Printout FORMAT
 
-    # terminate session
-    if rst.currentSession is not None and rst.currentSession.started:
-        rst.currentSession.killSession()
-
-    # Render html
-    htmlStrTop = '<html><head><title>Conformance Test Summary</title>\
-            <style>\
-            .pass {background-color:#99EE99}\
-            .fail {background-color:#EE9999}\
-            .warn {background-color:#EEEE99}\
-            .bluebg {background-color:#BDD6EE}\
-            .button {padding: 12px; display: inline-block}\
-            .center {text-align:center;}\
-            .log {text-align:left; white-space:pre-wrap; word-wrap:break-word; font-size:smaller}\
-            .title {background-color:#DDDDDD; border: 1pt solid; font-height: 30px; padding: 8px}\
-            .titlesub {padding: 8px}\
-            .titlerow {border: 2pt solid}\
-            .results {transition: visibility 0s, opacity 0.5s linear; display: none; opacity: 0}\
-            .resultsShow {display: block; opacity: 1}\
-            body {background-color:lightgrey; border: 1pt solid; text-align:center; margin-left:auto; margin-right:auto}\
-            th {text-align:center; background-color:beige; border: 1pt solid}\
-            td {text-align:left; background-color:white; border: 1pt solid; word-wrap:break-word;}\
-            table {width:90%; margin: 0px auto; table-layout:fixed;}\
-            .titletable {width:100%}\
-            </style>\
-            </head>'
-
-    htmlStrBodyHeader = \
-        '<body><table><tr><th>' \
-        '<h2>##### Redfish Conformance Test Report #####</h2>' \
-        '<br>' \
-        '<h4><img align="center" alt="DMTF Redfish Logo" height="203" width="288"' \
-        'src="data:image/gif;base64,' + logo.logo + '"></h4>' \
-        '<br>' \
-        '<h4><a href="https://github.com/DMTF/Redfish-Service-Validator">' \
-        'https://github.com/DMTF/Redfish-Service-Validator</a>' \
-        '<br>Tool Version: ' + tool_version + \
-        '<br>' + startTick.strftime('%c') + \
-        '<br>(Run time: ' + str(nowTick-startTick).rsplit('.', 1)[0] + ')' \
-        '' \
-        '<h4>This tool is provided and maintained by the DMTF. ' \
-        'For feedback, please open issues<br>in the tool\'s Github repository: ' \
-        '<a href="https://github.com/DMTF/Redfish-Service-Validator/issues">' \
-        'https://github.com/DMTF/Redfish-Service-Validator/issues</a></h4>' \
-        '</th></tr>' \
-        '<tr><th>' \
-        '<h4>System: <a href="' + ConfigURI + '">' + ConfigURI + '</a> Description: ' + sysDescription + '</h4>' \
-        '</th></tr>' \
-        '<tr><th>' \
-        '<h4>Configuration:</h4>' \
-        '<h4>' + str(config_str.replace('\n', '<br>')) + '</h4>' \
-        '</th></tr>' \
-        ''
-
-    htmlStr = rst.metadata.to_html()
     finalCounts.update(rst.metadata.get_counter())
-
-    rsvLogger.info(len(results))
-    for cnt, item in enumerate(results):
-        type_name = ''
-        prop_type = results[item][6]
-        if prop_type is not None:
-            namespace = prop_type.replace('#', '').rsplit('.', 1)[0]
-            type_name = prop_type.replace('#', '').rsplit('.', 1)[-1]
-            if '.' in namespace:
-                type_name += ' ' + namespace.split('.', 1)[-1]
-        htmlStr += '<tr><th class="titlerow bluebg"><b>{}</b> ({})</th></tr>'.format(results[item][0], type_name)
-        htmlStr += '<tr><td class="titlerow"><table class="titletable"><tr>'
-        htmlStr += '<td class="title" style="width:40%"><div>{}</div>\
-                <div class="button warn" onClick="document.getElementById(\'resNum{}\').classList.toggle(\'resultsShow\');">Show results</div>\
-                </td>'.format(results[item][0], cnt, cnt)
-        htmlStr += '<td class="titlesub log" style="width:30%"><div><b>Schema File:</b> {}</div><div><b>Resource Type:</b> {}</div></td>'.format(results[item][5], type_name)
-        htmlStr += '<td style="width:10%"' + \
-            ('class="pass"> GET Success' if results[item]
-             [1] else 'class="fail"> GET Failure') + '</td>'
-        htmlStr += '<td style="width:10%">'
-
-        innerCounts = results[item][2]
-        finalCounts.update(innerCounts)
+    for item in results:
+        innerCounts = results[item]['counts']
 
         # detect if there are error messages for this resource, but no failure counts; if so, add one to the innerCounts
         counters_all_pass = True
         for countType in sorted(innerCounts.keys()):
-            if 'problem' in countType or 'fail' in countType or 'exception' in countType:
+            if any(x in countType for x in ['problem', 'fail', 'bad', 'exception']):
                 counters_all_pass = False
                 break
         error_messages_present = False
-        if results[item][4] is not None and len(results[item][4].getvalue()) > 0:
+        if results[item]['errors'] is not None and len(results[item]['errors'].getvalue()) > 0:
             error_messages_present = True
         if counters_all_pass and error_messages_present:
             innerCounts['failSchema'] = 1
 
-        for countType in sorted(innerCounts.keys()):
-            if 'problem' in countType or 'fail' in countType or 'exception' in countType:
-                rsvLogger.error('{} {} errors in {}'.format(innerCounts[countType], countType, str(results[item][0]).split(' ')[0]))  # Printout FORMAT
-            innerCounts[countType] += 0
-            if 'fail' in countType or 'exception' in countType:
-                style = 'class="fail log"'
-            elif 'warn' in countType:
-                style = 'class="warn log"'
-            else:
-                style = 'class=log'
-            htmlStr += '<div {style}>{p}: {q}</div>'.format(
-                    p=countType,
-                    q=innerCounts.get(countType, 0),
-                    style=style)
-        htmlStr += '</td></tr>'
-        htmlStr += '</table></td></tr>'
-        htmlStr += '<tr><td class="results" id=\'resNum{}\'><table><tr><td><table><tr><th style="width:15%">Property Name</th> <th>Value</th> <th>Type</th> <th style="width:10%">Exists?</th> <th style="width:10%">Result</th> <tr>'.format(cnt)
-        if results[item][3] is not None:
-            for i in results[item][3]:
-                htmlStr += '<tr>'
-                htmlStr += '<td>' + str(i) + '</td>'
-                for j in results[item][3][i][:-1]:
-                    htmlStr += '<td >' + str(j) + '</td>'
-                # only color-code the last ("Success") column
-                success_col = results[item][3][i][-1]
-                if 'FAIL' in str(success_col).upper():
-                    htmlStr += '<td class="fail center">' + str(success_col) + '</td>'
-                elif 'DEPRECATED' in str(success_col).upper():
-                    htmlStr += '<td class="warn center">' + str(success_col) + '</td>'
-                elif 'PASS' in str(success_col).upper():
-                    htmlStr += '<td class="pass center">' + str(success_col) + '</td>'
-                else:
-                    htmlStr += '<td class="center">' + str(success_col) + '</td>'
-                htmlStr += '</tr>'
-        htmlStr += '</table></td></tr>'
-        if results[item][4] is not None:
-            htmlStr += '<tr><td class="fail log">' + html.escape(results[item][4].getvalue()).replace('\n', '<br />') + '</td></tr>'
-            results[item][4].close()
-        htmlStr += '<tr><td>---</td></tr></table></td></tr>'
-
-    htmlStr += '</table></body></html>'
-
-    htmlStrTotal = '<tr><td><div>Final counts: '
-    for countType in sorted(finalCounts.keys()):
-        htmlStrTotal += '{p}: {q},   '.format(p=countType, q=finalCounts.get(countType, 0))
-    htmlStrTotal += '</div><div class="button warn" onClick="arr = document.getElementsByClassName(\'results\'); for (var i = 0; i < arr.length; i++){arr[i].className = \'results resultsShow\'};">Expand All</div>'
-    htmlStrTotal += '</div><div class="button fail" onClick="arr = document.getElementsByClassName(\'results\'); for (var i = 0; i < arr.length; i++){arr[i].className = \'results\'};">Collapse All</div>'
-
-    htmlPage = htmlStrTop + htmlStrBodyHeader + htmlStrTotal + htmlStr
-
-    lastResultsPage = datetime.strftime(startTick, os.path.join(logpath, "ConformanceHtmlLog_%m_%d_%Y_%H%M%S.html"))
-    with open(lastResultsPage, 'w', encoding='utf-8') as f:
-        f.write(htmlPage)
+        finalCounts.update(results[item]['counts'])
 
     fails = 0
-    for key in finalCounts:
-        if 'problem' in key or 'fail' in key or 'exception' in key:
+    for key in [key for key in finalCounts.keys()]:
+        if finalCounts[key] == 0:
+            del finalCounts[key]
+            continue
+        if any(x in key for x in ['problem', 'fail', 'bad', 'exception']):
             fails += finalCounts[key]
+        
+    html_str = renderHtml(results, finalCounts, tool_version, startTick, nowTick)
+    
+    lastResultsPage = datetime.strftime(startTick, os.path.join(logpath, "ConformanceHtmlLog_%m_%d_%Y_%H%M%S.html"))
 
+    writeHtml(html_str, lastResultsPage)
+    
     success = success and not (fails > 0)
     rsvLogger.info(finalCounts)
 
@@ -1594,7 +1321,6 @@ def main(configpsr=None):
         status_code = 0
 
     return status_code, lastResultsPage, 'Validation done'
-
 
 if __name__ == '__main__':
     status_code, lastResultsPage, exit_string = main()

--- a/RedfishServiceValidatorGui.py
+++ b/RedfishServiceValidatorGui.py
@@ -321,7 +321,7 @@ class RSVGui:
         # Launch the validator
         try:
             rsv_config = self.build_config_parser( False )
-            status_code, last_results_page, exit_string = rsv.main( rsv_config )
+            status_code, last_results_page, exit_string = rsv.main(direct_parser = rsv_config )
             if last_results_page != None:
                 webbrowser.open_new( last_results_page )
             else:

--- a/cache/README.md
+++ b/cache/README.md
@@ -1,0 +1,11 @@
+To use cache, place modified files into this directory similar to Redfish mockup directory structure.
+
+To replace your ServiceRoot, place 'index.json' to './cache/redfish/v1/', then use command line options:
+
+
+
+`python3 RedfishServiceValidator.py --cache Prefer ./cache`
+
+
+
+Or the config file option listed in config.ini

--- a/simpletypes.py
+++ b/simpletypes.py
@@ -1,0 +1,123 @@
+
+# Copyright Notice:
+# Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Service-Validator/blob/master/LICENSE.md
+
+import re
+import traverseService as rst
+
+rsvLogger = rst.getLogger()
+rsvLogger.disabled = True
+
+def validateDeprecatedEnum(name, val, listEnum):
+    """
+    Validates a DeprecatedEnum
+    """
+    paramPass = True
+    if isinstance(val, list):
+        display_val = []
+        for enumItem in val:
+            display_val.append(dict(enumItem))
+            for k, v in enumItem.items():
+                paramPass = paramPass and str(v) in listEnum
+        if not paramPass:
+            rsvLogger.error("{}: Invalid DeprecatedEnum value '{}' found, expected {}"
+                            .format(str(name), display_val, str(listEnum)))
+    elif isinstance(val, str):
+        paramPass = str(val) in listEnum
+        if not paramPass:
+            rsvLogger.error("{}: Invalid DeprecatedEnum value '{}' found, expected {}"
+                            .format(str(name), val, str(listEnum)))
+    else:
+        rsvLogger.error("{}: Expected list or string value for DeprecatedEnum, got {}".format(str(name), str(type(val)).strip('<>')))
+    return paramPass
+
+
+def validateEnum(name, val, listEnum):
+    paramPass = isinstance(val, str)
+    if paramPass:
+        paramPass = val in listEnum
+        if not paramPass:
+            rsvLogger.error("{}: Invalid Enum value '{}' found, expected {}".format(str(name), val, str(listEnum)))
+    else:
+        rsvLogger.error("{}: Expected string value for Enum, got {}".format(str(name), str(type(val)).strip('<>')))
+    return paramPass
+
+
+def validateString(name, val, pattern=None):
+    """
+    Validates a string, given a value and a pattern
+    """
+    paramPass = isinstance(val, str)
+    if paramPass:
+        if pattern is not None:
+            match = re.fullmatch(pattern, val)
+            paramPass = match is not None
+            if not paramPass:
+                rsvLogger.error("{}: String '{}' does not match pattern '{}'".format(name, str(val), str(pattern)))
+        else:
+            paramPass = True
+    else:
+        rsvLogger.error("{}: Expected string value, got type {}".format(name, str(type(val)).strip('<>')))
+    return paramPass
+
+
+def validateDatetime(name, val):
+    """
+    Validates a Datetime, given a value (pattern predetermined)
+    """
+    paramPass = validateString(name, val, '.*(Z|(\+|-)[0-9][0-9]:[0-9][0-9])')
+    if not paramPass:
+        rsvLogger.error("\t...: Malformed DateTimeOffset")
+    return paramPass
+
+
+def validateGuid(name, val):
+    """
+    Validates a Guid, given a value (pattern predetermined)
+    """
+    paramPass = validateString(name, val, "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+    if not paramPass:
+        rsvLogger.error("\t...: Malformed Guid")
+    return paramPass
+
+
+def validateInt(name, val, minVal=None, maxVal=None):
+    """
+    Validates a Int, then passes info to validateNumber
+    """
+    if not isinstance(val, int):
+        rsvLogger.error("{}: Expected integer, got type {}".format(name, str(type(val)).strip('<>')))
+        return False
+    else:
+        return validateNumber(name, val, minVal, maxVal)
+
+
+def validateNumber(name, val, minVal=None, maxVal=None):
+    """
+    Validates a Number and its min/max values
+    """
+    paramPass = isinstance(val, (int, float))
+    if paramPass:
+        if minVal is not None:
+            paramPass = paramPass and minVal <= val
+            if not paramPass:
+                rsvLogger.error("{}: Value out of assigned min range, {} < {}".format(name, str(val), str(minVal)))
+        if maxVal is not None:
+            paramPass = paramPass and maxVal >= val
+            if not paramPass:
+                rsvLogger.error("{}: Value out of assigned max range, {} > {}".format(name, str(val), str(maxVal)))
+    else:
+        rsvLogger.error("{}: Expected integer or float, got type {}".format(name, str(type(val)).strip('<>')))
+    return paramPass
+
+
+def validatePrimitive(name, val):
+    """
+    Validates a Primitive
+    """
+    if isinstance(val, (int, float, str, bool)):
+        return True
+    else:
+        rsvLogger.error("{}: Expected primitive type, got type {}".format(name, str(type(val)).strip('<>')))
+        return False

--- a/simpletypes.py
+++ b/simpletypes.py
@@ -7,7 +7,6 @@ import re
 import traverseService as rst
 
 rsvLogger = rst.getLogger()
-rsvLogger.disabled = True
 
 def validateDeprecatedEnum(name, val, listEnum):
     """

--- a/tests/simpleeval.py
+++ b/tests/simpleeval.py
@@ -14,6 +14,10 @@ import sys
 sys.path.append('../')
 
 from simpletypes import *
+import traverseService as rst
+
+rsvLogger = rst.getLogger()
+rsvLogger.disabled = True
 
 class ValidatorTest(TestCase):
 

--- a/tests/simpleeval.py
+++ b/tests/simpleeval.py
@@ -10,7 +10,10 @@ from unittest import TestCase
 from unittest import mock
 import datetime
 
-import RedfishServiceValidator as rsv
+import sys
+sys.path.append('../')
+
+from simpletypes import *
 
 class ValidatorTest(TestCase):
 
@@ -26,7 +29,7 @@ class ValidatorTest(TestCase):
         ranges = [empty, empty, (0, None), (None, 21), empty, empty, (0, 15), empty] 
         for num, rang in zip(numbers, ranges):
             minx, maxx = rang
-            paramPass = rsv.validateNumber("TestNum", num,  minx, maxx)
+            paramPass = validateNumber("TestNum", num,  minx, maxx)
             self.assertTrue(paramPass,'This number has failed, {} {}'.format(num,  (minx, maxx)))
 
     def test_validate_int(self):
@@ -35,56 +38,56 @@ class ValidatorTest(TestCase):
         ranges = [empty, empty, (0, None), (None, 21), empty, empty] 
         for num, rang in zip(numbers, ranges):
             minx, maxx = rang
-            paramPass = rsv.validateInt("TestNum", num,  minx, maxx)
+            paramPass = validateInt("TestNum", num,  minx, maxx)
             self.assertTrue(paramPass == isinstance(num, int),'This number has failed, {} {}'.format(num,  (minx, maxx)))
     
     def test_validate_string(self):
         name, string, pattern = "tst", "TestString", None
-        self.assertTrue(rsv.validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
+        self.assertTrue(validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
         name, string, pattern = "tst", "Test_String", "Test.String"
-        self.assertTrue(rsv.validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
+        self.assertTrue(validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
         name, string, pattern = "tst", "100.97.143.52", "^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"
-        self.assertTrue(rsv.validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
+        self.assertTrue(validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
     
     def test_validate_badstring(self):
         name, string, pattern = "tst", 1, None
-        self.assertFalse(rsv.validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
+        self.assertFalse(validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
         name, string, pattern = "tst", "Test__String", "Test.String"
-        self.assertFalse(rsv.validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
+        self.assertFalse(validateString(name, string, pattern),'This string/pattern has failed, {} {}'.format(string,pattern))
     
     def test_validate_datetime(self):
         name, string = 'date', "2017-05-11T16:30:46-05:00"
-        self.assertTrue(rsv.validateDatetime(name, string),'This datetime has failed: {}'.format(string))
+        self.assertTrue(validateDatetime(name, string),'This datetime has failed: {}'.format(string))
         name, string = 'baddate', "baddate"
-        self.assertFalse(rsv.validateDatetime(name, string),'This datetime has failed: {}'.format(string))
+        self.assertFalse(validateDatetime(name, string),'This datetime has failed: {}'.format(string))
          
     def test_validate_guid(self):
         name, string = 'guid', "deadb33f-0048-3310-8039-01004f003432" 
-        self.assertTrue(rsv.validateGuid(name, string),'This guid has failed: {}'.format(string))
+        self.assertTrue(validateGuid(name, string),'This guid has failed: {}'.format(string))
         name, string = 'badguid', "badguid"
-        self.assertFalse(rsv.validateGuid(name, string),'This guid has failed: {}'.format(string))
+        self.assertFalse(validateGuid(name, string),'This guid has failed: {}'.format(string))
     
     def test_validate_enum(self):
         enums = ['OK','Not OK']
         name, string = 'enum', 'OK'
-        self.assertTrue(rsv.validateEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
+        self.assertTrue(validateEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
         name, string = 'enum', 'Not OK'
-        self.assertTrue(rsv.validateEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
+        self.assertTrue(validateEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
         name, string = 'badenum', 'DNE'
-        self.assertFalse(rsv.validateEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
+        self.assertFalse(validateEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
         name, string = 'badenum', 'Ok'
-        self.assertFalse(rsv.validateEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
+        self.assertFalse(validateEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
     
     def test_validate_denum(self):
         enums = ['OK','Not OK']
         name, string = 'enum', 'OK'
-        self.assertTrue(rsv.validateDeprecatedEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
+        self.assertTrue(validateDeprecatedEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
         name, string = 'enum', [{'Member':'Not OK'}]
-        self.assertTrue(rsv.validateDeprecatedEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
+        self.assertTrue(validateDeprecatedEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
         name, string = 'badenum', 'DNE'
-        self.assertFalse(rsv.validateDeprecatedEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
+        self.assertFalse(validateDeprecatedEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
         name, string = 'badenum', [{'Member':'Ok'}]
-        self.assertFalse(rsv.validateDeprecatedEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
+        self.assertFalse(validateDeprecatedEnum(name, string, enums),'This enum has failed: {} {}'.format(string, enums))
     
     def test_validate_complex(self):
         self.assertTrue(True,'Huh?')

--- a/tohtml.py
+++ b/tohtml.py
@@ -1,0 +1,150 @@
+
+# Copyright Notice:
+# Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Service-Validator/blob/master/LICENSE.md
+
+import traverseService as rst
+import RedfishLogo as logo
+import html
+
+def resultTupleToDict():
+    pass 
+
+def renderHtml(results, finalCounts, tool_version, startTick, nowTick):
+    # Render html
+    config = rst.config
+    config_str = rst.configToStr()
+    rsvLogger = rst.getLogger()
+    sysDescription, ConfigURI = (config['systeminfo'], config['targetip'])
+    logpath = config['logpath']
+
+    htmlStrTop = '<html><head><title>Conformance Test Summary</title>\
+            <style>\
+            .pass {background-color:#99EE99}\
+            .fail {background-color:#EE9999}\
+            .warn {background-color:#EEEE99}\
+            .bluebg {background-color:#BDD6EE}\
+            .button {padding: 12px; display: inline-block}\
+            .center {text-align:center;}\
+            .log {text-align:left; white-space:pre-wrap; word-wrap:break-word; font-size:smaller}\
+            .title {background-color:#DDDDDD; border: 1pt solid; font-height: 30px; padding: 8px}\
+            .titlesub {padding: 8px}\
+            .titlerow {border: 2pt solid}\
+            .results {transition: visibility 0s, opacity 0.5s linear; display: none; opacity: 0}\
+            .resultsShow {display: block; opacity: 1}\
+            body {background-color:lightgrey; border: 1pt solid; text-align:center; margin-left:auto; margin-right:auto}\
+            th {text-align:center; background-color:beige; border: 1pt solid}\
+            td {text-align:left; background-color:white; border: 1pt solid; word-wrap:break-word;}\
+            table {width:90%; margin: 0px auto; table-layout:fixed;}\
+            .titletable {width:100%}\
+            </style>\
+            </head>'
+
+    htmlStrBodyHeader = \
+        '<body><table><tr><th>' \
+        '<h2>##### Redfish Conformance Test Report #####</h2>' \
+        '<br>' \
+        '<h4><img align="center" alt="DMTF Redfish Logo" height="203" width="288"' \
+        'src="data:image/gif;base64,' + logo.logo + '"></h4>' \
+        '<br>' \
+        '<h4><a href="https://github.com/DMTF/Redfish-Service-Validator">' \
+        'https://github.com/DMTF/Redfish-Service-Validator</a>' \
+        '<br>Tool Version: ' + tool_version + \
+        '<br>' + startTick.strftime('%c') + \
+        '<br>(Run time: ' + str(nowTick-startTick).rsplit('.', 1)[0] + ')' \
+        '' \
+        '<h4>This tool is provided and maintained by the DMTF. ' \
+        'For feedback, please open issues<br>in the tool\'s Github repository: ' \
+        '<a href="https://github.com/DMTF/Redfish-Service-Validator/issues">' \
+        'https://github.com/DMTF/Redfish-Service-Validator/issues</a></h4>' \
+        '</th></tr>' \
+        '<tr><th>' \
+        '<h4>System: <a href="' + ConfigURI + '">' + ConfigURI + '</a> Description: ' + sysDescription + '</h4>' \
+        '</th></tr>' \
+        '<tr><th>' \
+        '<h4>Configuration:</h4>' \
+        '<h4>' + str(config_str.replace('\n', '<br>')) + '</h4>' \
+        '</th></tr>' \
+        ''
+
+    htmlStr = rst.metadata.to_html()
+
+    rsvLogger.info(len(results))
+    for cnt, item in enumerate(results):
+        type_name = ''
+        prop_type = results[item]['fulltype']
+        if prop_type is not None:
+            namespace = prop_type.replace('#', '').rsplit('.', 1)[0]
+            type_name = prop_type.replace('#', '').rsplit('.', 1)[-1]
+            if '.' in namespace:
+                type_name += ' ' + namespace.split('.', 1)[-1]
+        htmlStr += '<tr><th class="titlerow bluebg"><b>{}</b> ({})</th></tr>'.format(results[item]['uri'], type_name)
+        htmlStr += '<tr><td class="titlerow"><table class="titletable"><tr>'
+        htmlStr += '<td class="title" style="width:40%"><div>{}</div>\
+                <div class="button warn" onClick="document.getElementById(\'resNum{}\').classList.toggle(\'resultsShow\');">Show results</div>\
+                </td>'.format(results[item]['uri'], cnt, cnt)
+        htmlStr += '<td class="titlesub log" style="width:30%"><div><b>Schema File:</b> {}</div><div><b>Resource Type:</b> {}</div></td>'.format(results[item]['context'], type_name)
+        htmlStr += '<td style="width:10%"' + \
+            ('class="pass"> GET Success' if results[item]['success'] else 'class="fail"> GET Failure') + '</td>'
+        htmlStr += '<td style="width:10%">'
+
+        innerCounts = results[item]['counts']
+
+        for countType in sorted(innerCounts.keys()):
+            if 'problem' in countType or 'fail' in countType or 'exception' in countType:
+                rsvLogger.error('{} {} errors in {}'.format(innerCounts[countType], countType, str(results[item]['uri']).split(' ')[0]))  # Printout FORMAT
+            innerCounts[countType] += 0
+            if 'fail' in countType or 'exception' in countType:
+                style = 'class="fail log"'
+            elif 'warn' in countType:
+                style = 'class="warn log"'
+            else:
+                style = 'class=log'
+            htmlStr += '<div {style}>{p}: {q}</div>'.format(
+                    p=countType,
+                    q=innerCounts.get(countType, 0),
+                    style=style)
+        htmlStr += '</td></tr>'
+        htmlStr += '</table></td></tr>'
+        htmlStr += '<tr><td class="results" id=\'resNum{}\'><table><tr><td><table><tr><th style="width:15%">Property Name</th> <th>Value</th> <th>Type</th> <th style="width:10%">Exists?</th> <th style="width:10%">Result</th> <tr>'.format(cnt)
+        if results[item]['messages'] is not None:
+            messages = results[item]['messages']
+            for i in messages:
+                htmlStr += '<tr>'
+                htmlStr += '<td>' + str(i) + '</td>'
+                for j in messages[i][:-1]:
+                    htmlStr += '<td >' + str(j) + '</td>'
+                # only color-code the last ("Success") column
+                success_col = messages[i][-1]
+                if 'FAIL' in str(success_col).upper():
+                    htmlStr += '<td class="fail center">' + str(success_col) + '</td>'
+                elif 'DEPRECATED' in str(success_col).upper():
+                    htmlStr += '<td class="warn center">' + str(success_col) + '</td>'
+                elif 'PASS' in str(success_col).upper():
+                    htmlStr += '<td class="pass center">' + str(success_col) + '</td>'
+                else:
+                    htmlStr += '<td class="center">' + str(success_col) + '</td>'
+                htmlStr += '</tr>'
+        htmlStr += '</table></td></tr>'
+        if results[item]['errors'] is not None:
+            htmlStr += '<tr><td class="fail log">' + html.escape(results[item]['errors'].getvalue()).replace('\n', '<br />') + '</td></tr>'
+            results[item]['errors'].close()
+        htmlStr += '<tr><td>---</td></tr></table></td></tr>'
+
+    htmlStr += '</table></body></html>'
+
+    htmlStrTotal = '<tr><td><div>Final counts: '
+    for countType in sorted(finalCounts.keys()):
+        htmlStrTotal += '{p}: {q},   '.format(p=countType, q=finalCounts.get(countType, 0))
+    htmlStrTotal += '</div><div class="button warn" onClick="arr = document.getElementsByClassName(\'results\'); for (var i = 0; i < arr.length; i++){arr[i].className = \'results resultsShow\'};">Expand All</div>'
+    htmlStrTotal += '</div><div class="button fail" onClick="arr = document.getElementsByClassName(\'results\'); for (var i = 0; i < arr.length; i++){arr[i].className = \'results\'};">Collapse All</div>'
+
+    htmlPage = htmlStrTop + htmlStrBodyHeader + htmlStrTotal + htmlStr
+
+    return htmlPage
+
+
+def writeHtml(string, path):
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(string)
+

--- a/tohtml.py
+++ b/tohtml.py
@@ -129,6 +129,9 @@ def renderHtml(results, finalCounts, tool_version, startTick, nowTick):
         if results[item]['errors'] is not None:
             htmlStr += '<tr><td class="fail log">' + html.escape(results[item]['errors'].getvalue()).replace('\n', '<br />') + '</td></tr>'
             results[item]['errors'].close()
+        if results[item]['warns'] is not None:
+            htmlStr += '<tr><td class="warn log">' + html.escape(results[item]['warns'].getvalue()).replace('\n', '<br />') + '</td></tr>'
+            results[item]['warns'].close()
         htmlStr += '<tr><td>---</td></tr></table></td></tr>'
 
     htmlStr += '</table></body></html>'

--- a/traverseService.py
+++ b/traverseService.py
@@ -106,8 +106,9 @@ def convertConfigParserToDict(configpsr):
     return cdict
 
 def setByArgparse(args):
+    ch.setLevel(args.verbose_checks)
     if args.v:
-        lg.stdOutHandler.setLevel(logging.DEBUG)
+        ch.setLevel(logging.DEBUG)
     if args.config is not None:
         configpsr = configparser.ConfigParser()
         configpsr.read(args.config)
@@ -576,14 +577,6 @@ def getReferenceDetails(soup, metadata_dict=None, name='xml'):
     cntref = len(refDict)
     if metadata_dict is not None:
         refDict.update(metadata_dict)
-        if len(refDict.keys()) > len(metadata_dict.keys()):
-            diff_keys = [key for key in refDict if key not in metadata_dict]
-            traverseLogger.log(
-                    logging.ERROR if ServiceOnly else logging.DEBUG,
-                    "Reference in a Schema {} not in metadata, this may not be compatible with ServiceMode".format(name))
-            traverseLogger.log(
-                    logging.ERROR if ServiceOnly else logging.DEBUG,
-                    "References missing in metadata: {}".format(str(diff_keys)))
     traverseLogger.debug("References generated from {}: {} out of {}".format(name, cntref, len(refDict)))
     return refDict
 
@@ -1297,5 +1290,5 @@ def getAnnotations(soup, refs, decoded, prefix=''):
                 tagtype = 'Term'
             additionalProps.append(
                 PropItem(annotationSoup, annotationRefs, realItem, key, tagtype, None))
-    traverseLogger.info("Annotations generated: {} out of {}".format(len(additionalProps), annotationsFound))
+    traverseLogger.debug("Annotations generated: {} out of {}".format(len(additionalProps), annotationsFound))
     return True, additionalProps

--- a/traverseService.py
+++ b/traverseService.py
@@ -23,7 +23,6 @@ import metadata as md
 
 traverseLogger = logging.getLogger(__name__)
 traverseLogger.setLevel(logging.DEBUG)
-traverseLogger.disabled = False
 ch = logging.StreamHandler(sys.stdout)
 ch.setLevel(logging.INFO)
 traverseLogger.addHandler(ch)

--- a/traverseService.py
+++ b/traverseService.py
@@ -18,25 +18,24 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from http.client import responses
 import copy
 
+import metadata as md
+
 
 traverseLogger = logging.getLogger(__name__)
 traverseLogger.setLevel(logging.DEBUG)
+traverseLogger.disabled = False
 ch = logging.StreamHandler(sys.stdout)
 ch.setLevel(logging.INFO)
 traverseLogger.addHandler(ch)
 
 commonHeader = {'OData-Version': '4.0'}
-proxies = {'http': None, 'https': None}
-
-currentSession = None
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 # dictionary to hold sampling notation strings for URIs
 uri_sample_map = dict()
 
-# holds instance of Metadata class for $metadata processing and validation
+currentService = None
 metadata = None
-
 
 class AuthenticationError(Exception):
     """Exception used for failed basic auth or token auth"""
@@ -51,73 +50,175 @@ def getLogger():
     return traverseLogger
 
 # default config
-configset = {
-        "targetip": type(""), "username": type(""), "password": type(""), "authtype": type(""), "usessl": type(True), "certificatecheck": type(True), "certificatebundle": type(""),
-        "metadatafilepath": type(""), "cachemode": (type(False),type("")), "cachefilepath": type(""), "schemasuffix": type(""), "timeout": type(0), "httpproxy": type(""), "httpsproxy": type(""),
-        "systeminfo": type(""), "localonlymode": type(True), "servicemode": type(True), "token": type(""), 'linklimit': dict, 'sample': type(0), 'extrajsonheaders': dict, 'extraxmlheaders': dict
+argparse2configparser = {
+        'user': 'username', 'nochkcert': '!certificatecheck', 'ca_bundle': 'certificatebundle', 'schemamode': 'schemamode',
+        'suffix': 'schemasuffix', 'schemadir': 'metadatafilepath', 'nossl': '!usessl', 'timeout': 'timeout', 'service': 'servicemode',
+        'http_proxy': 'httpproxy', 'localonly': 'localonlymode', 'https_proxy': 'httpsproxy', 'passwd': 'password',
+        'ip': 'targetip', 'logdir': 'logpath', 'desc': 'systeminfo', 'authtype': 'authtype',
+        'payload': 'payloadmode+payloadfilepath', 'cache': 'cachemode+cachefilepath', 'token': 'token',
+        'linklimit': 'linklimit', 'sample': 'sample'
         }
-config = {
+
+configset = {
+        "targetip": str, "username": str, "password": str, "authtype": str, "usessl": bool, "certificatecheck": bool, "certificatebundle": str,
+        "metadatafilepath": str, "cachemode": (bool, str), "cachefilepath": str, "schemasuffix": str, "timeout": int, "httpproxy": str, "httpsproxy": str,
+        "systeminfo": str, "localonlymode": bool, "servicemode": bool, "token": str, 'linklimit': dict, 'sample': int, 'extrajsonheaders': dict, 'extraxmlheaders': dict
+        }
+
+defaultconfig = {
         'authtype': 'basic', 'username': "", 'password': "", 'token': '',
         'certificatecheck': True, 'certificatebundle': "", 'metadatafilepath': './SchemaFiles/metadata',
         'cachemode': 'Off', 'cachefilepath': './cache', 'schemasuffix': '_v1.xml', 'httpproxy': "", 'httpsproxy': "",
         'localonlymode': False, 'servicemode': False, 'linklimit': {'LogEntry':20}, 'sample': 0
         }
 
+config = dict(defaultconfig)
+
+proxies = {}
+
+configSet = False
+
+def configToStr():
+    config_str = ""
+    for cnt, item in enumerate(sorted(list(config.keys() - set(['systeminfo', 'targetip', 'password', 'description']))), 1):
+        config_str += "{}: {},  ".format(str(item), str(config[item] if config[item] != '' else 'None'))
+        if cnt % 6 == 0:
+            config_str += '\n'
+    return config_str
+
+def convertConfigParserToDict(configpsr):
+    cdict = {}
+    for category in configpsr:
+        for option in configpsr[category]:
+            val = configpsr[category][option]
+            if option not in configset.keys() and category not in ['Information', 'Validator']:
+                traverseLogger.error('Config option {} in {} unsupported!'.format(option, category))
+            if val in ['', None]:
+                continue
+            if val.isdigit():
+                val = int(val)
+            elif option == 'linklimit':
+                val = re.findall('[A-Za-z_]+:[0-9]+', val)
+            elif str(val).lower() in ['on', 'true', 'yes']:
+                val = True
+            elif str(val).lower() in ['off', 'false', 'no']:
+                val = False
+            cdict[option] = val
+    return cdict
+
+def setByArgparse(args):
+    if args.v:
+        lg.stdOutHandler.setLevel(logging.DEBUG)
+    if args.config is not None:
+        configpsr = configparser.ConfigParser()
+        configpsr.read(args.config)
+        cdict = convertConfigParserToDict(configpsr)
+    else:
+        cdict = {}
+        for param in args.__dict__:
+            if param in argparse2configparser:
+                if isinstance(args.__dict__[param], list):
+                    for cnt, item in enumerate(argparse2configparser[param].split('+')):
+                        cdict[item] = args.__dict__[param][cnt]
+                elif '+' not in argparse2configparser[param]:
+                    if '!' in argparse2configparser[param]:
+                        cdict[argparse2configparser[param].replace('!','')] = not args.__dict__[param]
+                    else:
+                        cdict[argparse2configparser[param]] = args.__dict__[param]
+            else:
+                cdict[param] = args.__dict__[param]
+
+    setConfig(cdict)
+
+
 def setConfig(cdict):
     """
     Set config based on configurable dictionary
     """
+    # Send config only with keys supported by program
+    linklimitdict = {}
+    if cdict.get('linklimit') is not None:
+        for item in cdict.get('linklimit'):
+            if re.match('[A-Za-z_]+:[0-9]+', item) is not None:
+                typename, count = tuple(item.split(':')[:2])
+                if typename not in linklimitdict:
+                    linklimitdict[typename] = int(count)
+                else:
+                    traverseLogger.error('Limit already exists for {}'.format(typename))
+    cdict['linklimit'] = linklimitdict
+
     for item in cdict:
         if item not in configset:
-            traverseLogger.error('Unsupported {}'.format(item))
+            traverseLogger.debug('Unsupported {}'.format(item))
         elif not isinstance(cdict[item], configset[item]):
-            traverseLogger.error('Unsupported {}, expected type {}'.format(item, configset[item]))
-    
-    # Always keep LogEntry: 20
+            traversetraverseLogger.error('Unsupported {}, expected type {}'.format(item, configset[item]))
+
+    global config
+    config = dict(defaultconfig)
+
+    # set linklimit
     defaultlinklimit = config['linklimit']
 
     config.update(cdict)
+
+    config['configuri'] = ('https' if config.get('usessl', True) else 'http') + '://' + config['targetip']
+    config['certificatecheck'] = config.get('certificatecheck', True) and config.get('usessl', True)
     
     defaultlinklimit.update(config['linklimit'])
     config['linklimit'] = defaultlinklimit
 
-    User, Passwd, Ip, ChkCert, UseSSL = config['username'], config['password'], config['targetip'], config['certificatecheck'], config['usessl']
-    
-    config['configuri'] = ('https' if UseSSL else 'http') + '://' + Ip
-
-    config['certificatecheck'] = ChkCert and UseSSL
-
-    # Convert list of strings to dict
-    chkcertbundle = config['certificatebundle']
-    if chkcertbundle not in [None, ""] and config['certificatecheck']:
-        if not os.path.isfile(chkcertbundle) and not os.path.isdir(chkcertbundle):
-            chkcertbundle = None
-            traverseLogger.error('ChkCertBundle is not found, defaulting to None')
-    else:
-        config['certificatebundle'] = None
-
-    httpprox = config['httpproxy']
-    httpsprox = config['httpsproxy']
-    proxies['http'] = httpprox if httpprox != "" else None
-    proxies['https'] = httpsprox if httpsprox != "" else None
-
     if config['cachemode'] not in ['Off', 'Fallback', 'Prefer']:
         if config['cachemode'] is not False:
-            traverseLogger.error('CacheMode or path invalid, defaulting to Off')
+            traversetraverseLogger.error('CacheMode or path invalid, defaulting to Off')
         config['cachemode'] = 'Off'
 
     AuthType = config['authtype']
     if AuthType not in ['None', 'Basic', 'Session', 'Token']:
         config['authtype'] = 'Basic'
-        traverseLogger.error('AuthType invalid, defaulting to Basic')
+        traversetraverseLogger.error('AuthType invalid, defaulting to Basic')
 
-    if AuthType == 'Session':
-        certVal = chkcertbundle if ChkCert and chkcertbundle is not None else ChkCert
-        global currentSession
-        # no proxy for system under test
-        currentSession = rfSession(User, Passwd, config['configuri'], logger=traverseLogger,
-                                   chkCert=certVal, proxies=None)
+    global currentService
+    if currentService is not None:
+        currentService.close()
+    currentService = rfService(config)
 
+
+class rfService():
+    def __init__(self, config):
+        self.config = config
+        self.proxies = dict()
+
+        config['configuri'] = ('https' if config.get('usessl', True) else 'http') + '://' + config['targetip']
+        httpprox = config['httpproxy']
+        httpsprox = config['httpsproxy']
+        proxies['http'] = httpprox if httpprox != "" else None
+        proxies['https'] = httpsprox if httpsprox != "" else None
+
+        # Convert list of strings to dict
+        self.chkcertbundle = config['certificatebundle']
+        chkcertbundle = self.chkcertbundle
+        if chkcertbundle not in [None, ""] and config['certificatecheck']:
+            if not os.path.isfile(chkcertbundle) and not os.path.isdir(chkcertbundle):
+                self.chkcertbundle = None
+                traverseLogger.error('ChkCertBundle is not found, defaulting to None')
+        else:
+            config['certificatebundle'] = None
+
+        ChkCert = config['certificatecheck']
+        AuthType = config['authtype']
+        self.currentSession = None
+        if AuthType == 'Session':
+            certVal = chkcertbundle if ChkCert and chkcertbundle is not None else ChkCert
+            # no proxy for system under test
+            self.currentSession = rfSession(config['user'], config['password'], config['configuri'], None, certVal, proxies)
+        
+        global metadata
+        metadata = md.Metadata(traverseLogger)
+
+    def close(self):
+        if self.currentSession is not None and self.currentSession.started:
+            self.currentSession.killSession()
+            
 
 def isNonService(uri):
     """
@@ -1122,6 +1223,8 @@ def getAllLinks(jsonData, propList, refDict, prefix='', context='', linklimits=N
                                  propDict.get('OData.AutoExpand'.lower(), None) is not None
                     cSchema = refDict.get(getNamespace(cType), (None, None))[1]
                     for k, v in insideItem.items():
+                        if not isinstance(v, dict):
+                            continue
                         uri = v.get('@Redfish.ActionInfo')
                         if isinstance(uri, str):
                             uriItem = {'@odata.id': uri}


### PR DESCRIPTION
Repartitioned pieces of code for easier unittesting in the future.

Implemented partial log changes similar to issue #212, only reporting errors and warns.  Now has the option to display extensive testing data with --verbose_checks.

Split warns and errors in HTML log to differentiate the messages.

Examples:

```
 % python3 RedfishServiceValidator.py --ip 127.0.0.1:8000 --nossl
ConfigURI: 127.0.0.1:8000
System Info: No desc
authtype: Basic,  cachefilepath: ./cache,  cachemode: Off,  certificatebundle: None,  certificatecheck: False,  config: None,  
configuri: http://127.0.0.1:8000,  debug_logging: 20,  httpproxy: None,  httpsproxy: None,  linklimit: {'LogEntry': 20},  localonlymode: False,  
logpath: ./logs,  metadatafilepath: ./SchemaFiles/metadata,  sample: 0,  schemasuffix: _v1.xml,  servicemode: False,  timeout: 30,  
token: None,  username: None,  usessl: False,  v: False,  verbose_checks: 20,  
Start time: 05/03/18 - 15:35:49
PayloadMode or path invalid, using Default behavior

*** /redfish/v1
         Type (ServiceRoot), GET SUCCESS (time: 0.008792)
         PASS

*** /redfish/v1/Systems
         Type (ComputerSystemCollection), GET SUCCESS (time: 0.009925)
         PASS

*** /redfish/v1/Systems/529QB9450R6
         Type (ComputerSystem), GET SUCCESS (time: 0.009507)
Actions.#ComputerSystem.SetDefaultBootOrder: action not found, is not mandatory
         PASS

*** /redfish/v1/Systems/529QB9450R6/Processors
         Type (ProcessorCollection), GET SUCCESS (time: 0.010553)
         PASS

*** /redfish/v1/Systems/529QB9450R6/Processors/CPU
         Type (Processor), GET SUCCESS (time: 0.008678)
         PASS
```



![image](https://user-images.githubusercontent.com/5571676/39601702-7b5d2b30-4ee8-11e8-9b3e-881ac3f8bd92.png)

