### PR TITLE
Add in ForceAuth option, Redfish.Copyright check

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ UserName = \<User ID of Administrator on the system\>
 
 Password = \<Password of the Administrator\>
 
-ForceAuth = \<Force authentication on otherwise insecure communication\>
+ForceAuth = \<Force authentication on otherwise unsecure communication\>
 
 AuthType = \<Type of authorization for above credentials (None,Basic,Session)\>
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ UserName = \<User ID of Administrator on the system\>
 
 Password = \<Password of the Administrator\>
 
+ForceAuth = \<Force authentication on otherwise insecure communication\>
+
 AuthType = \<Type of authorization for above credentials (None,Basic,Session)\>
 
 The Tool has an option to ignore SSL certificate check if certificate is not installed on the client system. The certificate check can be switched on or off using the below parameter of the config.ini file. By default the parameter is set to ‘Off’.  UseSSL determines whether or not the https protocol is used.  If it is `Off`, it will also disable certification.

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1197,7 +1197,7 @@ def main(argv=None, direct_parser=None):
     argget.add_argument('--timeout', type=int, default=30, help='requests timeout in seconds')
     argget.add_argument('--nochkcert', action='store_true', help='ignore check for certificate')
     argget.add_argument('--nossl', action='store_true', help='use http instead of https')
-    argget.add_argument('--forceauth', action='store_true', help='force authentication on insecure connections')
+    argget.add_argument('--forceauth', action='store_true', help='force authentication on unsecure connections')
     argget.add_argument('--authtype', type=str, default='Basic', help='authorization type (None|Basic|Session|Token)')
     argget.add_argument('--localonly', action='store_true', help='only use locally stored schema on your harddrive')
     argget.add_argument('--service', action='store_true', help='only use uris within the service')

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1192,6 +1192,7 @@ def main(argv=None, direct_parser=None):
     argget.add_argument('--timeout', type=int, default=30, help='requests timeout in seconds')
     argget.add_argument('--nochkcert', action='store_true', help='ignore check for certificate')
     argget.add_argument('--nossl', action='store_true', help='use http instead of https')
+    argget.add_argument('--forceauth', action='store_true', help='force authentication on insecure connections')
     argget.add_argument('--authtype', type=str, default='Basic', help='authorization type (None|Basic|Session|Token)')
     argget.add_argument('--localonly', action='store_true', help='only use locally stored schema on your harddrive')
     argget.add_argument('--service', action='store_true', help='only use uris within the service')
@@ -1266,7 +1267,7 @@ def main(argv=None, direct_parser=None):
     jsonData = None
    
     # Determine runner
-    pmode, ppath = config.get('payloadmode'), config.get('payloadfilepath')
+    pmode, ppath = config.get('payloadmode', 'Default'), config.get('payloadfilepath')
     if pmode not in ['Tree', 'Single', 'SingleFile', 'TreeFile', 'Default']:
         pmode = 'Default'
         rsvLogger.error('PayloadMode or path invalid, using Default behavior')

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1045,7 +1045,7 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
     if serviceSchemaSoup is not None:
         for prop in propResourceObj.additionalList:
             propMessages, propCounts = checkPropertyConformance(serviceSchemaSoup, prop.name, prop.propDict, propResourceObj.jsondata, serviceRefs)
-            if '@Redfish.Copyright' in propMessages:
+            if '@Redfish.Copyright' in propMessages and 'MessageRegistry' not in propResourceObj.typeobj.fulltype:
                 modified_entry = list(propMessages['@Redfish.Copyright'])
                 modified_entry[-1] = 'FAIL'
                 propMessages['@Redfish.Copyright'] = tuple(modified_entry)

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1045,6 +1045,11 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
     if serviceSchemaSoup is not None:
         for prop in propResourceObj.additionalList:
             propMessages, propCounts = checkPropertyConformance(serviceSchemaSoup, prop.name, prop.propDict, propResourceObj.jsondata, serviceRefs)
+            if '@Redfish.Copyright' in propMessages:
+                modified_entry = list(propMessages['@Redfish.Copyright'])
+                modified_entry[-1] = 'FAIL'
+                propMessages['@Redfish.Copyright'] = tuple(modified_entry)
+                rsvLogger.error('@Redfish.Copyright is only allowed for mockups, and should not be allowed in official implementations') 
             messages.update(propMessages)
             counts.update(propCounts)
 
@@ -1279,12 +1284,6 @@ def main(argv=None, direct_parser=None):
         else:
             rsvLogger.error('File not found: {}'.format(ppath))
             return 1, None, 'File not found: {}'.format(ppath)
-        # start session if using Session auth
-        if currentService.currentSession is not None:
-            success = currentService.currentSession.startSession()
-            if not success:
-                # terminate program on start session error (error logged in startSession() call above)
-                return 1, None, 'Could not establish a session with the service'
 
     try:
         if 'Single' in pmode:

--- a/config.ini
+++ b/config.ini
@@ -4,6 +4,7 @@ SystemInfo = Test Config, place your own description of target system here
 UserName = xuser
 Password = xpasswd
 AuthType = Basic
+ForceAuth = False
 Token = 
 UseSSL = True
 CertificateCheck = False

--- a/traverseService.py
+++ b/traverseService.py
@@ -220,10 +220,9 @@ class rfService():
                 config['username'] = ''
                 config['password'] = ''
         if AuthType == 'Session':
-            auth = (config['username'], config['password'])
             certVal = chkcertbundle if ChkCert and chkcertbundle is not None else ChkCert
             # no proxy for system under test
-            self.currentSession = rfSession(auth[0], auth[1], config['configuri'], None, certVal, self.proxies)
+            self.currentSession = rfSession(config['username'], config['password'], config['configuri'], None, certVal, self.proxies)
         
         self.metadata = md.Metadata(traverseLogger)
         self.active = True

--- a/traverseService.py
+++ b/traverseService.py
@@ -56,20 +56,21 @@ argparse2configparser = {
         'ip': 'targetip', 'logdir': 'logpath', 'desc': 'systeminfo', 'authtype': 'authtype',
         'payload': 'payloadmode+payloadfilepath', 'cache': 'cachemode+cachefilepath', 'token': 'token',
         'linklimit': 'linklimit', 'sample': 'sample'
-        }
+        } 
 
 configset = {
         "targetip": str, "username": str, "password": str, "authtype": str, "usessl": bool, "certificatecheck": bool, "certificatebundle": str,
         "metadatafilepath": str, "cachemode": (bool, str), "cachefilepath": str, "schemasuffix": str, "timeout": int, "httpproxy": str, "httpsproxy": str,
-        "systeminfo": str, "localonlymode": bool, "servicemode": bool, "token": str, 'linklimit': dict, 'sample': int, 'extrajsonheaders': dict, 'extraxmlheaders': dict, "schema_pack": str 
+        "systeminfo": str, "localonlymode": bool, "servicemode": bool, "token": str, 'linklimit': dict, 'sample': int, 'extrajsonheaders': dict, 'extraxmlheaders': dict, "schema_pack": str,
+        "forceauth": bool
         }
 
 defaultconfig = {
         'authtype': 'basic', 'username': "", 'password': "", 'token': '',
         'certificatecheck': True, 'certificatebundle': "", 'metadatafilepath': './SchemaFiles/metadata',
         'cachemode': 'Off', 'cachefilepath': './cache', 'schemasuffix': '_v1.xml', 'httpproxy': "", 'httpsproxy': "",
-        'localonlymode': False, 'servicemode': False, 'linklimit': {'LogEntry':20}, 'sample': 0, 'schema_pack': None
-        }
+        'localonlymode': False, 'servicemode': False, 'linklimit': {'LogEntry':20}, 'sample': 0, 'schema_pack': None, 'forceauth': False
+        } 
 
 config = dict(defaultconfig)
 
@@ -211,11 +212,18 @@ class rfService():
 
         ChkCert = config['certificatecheck']
         AuthType = config['authtype']
+            
         self.currentSession = None
+        if not config.get('usessl', True) and not config['forceauth']:
+            if config['username'] not in ['', None] or config['password'] not in ['', None]:
+                traverseLogger.warn('Attempting to authenticate on unchecked http/https protocol is insecure, if necessary please use ForceAuth option.  Clearing auth credentials...')
+                config['username'] = ''
+                config['password'] = ''
         if AuthType == 'Session':
+            auth = (config['username'], config['password'])
             certVal = chkcertbundle if ChkCert and chkcertbundle is not None else ChkCert
             # no proxy for system under test
-            self.currentSession = rfSession(config['user'], config['password'], config['configuri'], None, certVal, self.proxies)
+            self.currentSession = rfSession(auth[0], auth[1], config['configuri'], None, certVal, self.proxies)
         
         self.metadata = md.Metadata(traverseLogger)
         self.active = True
@@ -321,8 +329,9 @@ def callResourceURI(URILink):
 
     # rs-assertion: do not send auth over http
     # remove UseSSL if necessary if you require unsecure auth
-    if not UseSSL or nonService or AuthType != 'Basic':
+    if (not UseSSL and not config['forceauth']) or nonService or AuthType != 'Basic':
         auth = None
+
 
     # only send token when we're required to chkauth, during a Session, and on Service and Secure
     if UseSSL and not nonService and AuthType == 'Session' and not noauthchk:


### PR DESCRIPTION
Disables auth credentials if in a situation where forceauth is not specified but https/ssl is not being used. 

If Redfish.Copyright is checked, then throw an error and specify why.

