### PR TITLE
Adds Complex Dynamic checking and OEM Item/Link checking, reworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The Tool has an option to ignore SSL certificate check if certificate is not ins
 
 UseSSL = \<On / Off\>
 
+OemCheck = \<On / Off\>    Specify if we want to check OEM properties
+
 CertificateCheck = \<On / Off\>
 
 CertificateBundle = ca_bundle   Specify a bundle (file or directory) with certificates of trusted CAs. See [SelfSignedCerts.md](https://github.com/DMTF/Redfish-Service-Validator/blob/master/SelfSignedCerts.md) for tips on creating the bundle.

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -190,7 +190,7 @@ def validateComplex(name, val, propTypeObj, payloadType, attrRegistryId):
             propTypeObj = rst.PropType(val['@odata.type'], soup, refs, tagType='ComplexType')
             oemLinks.update(rst.getAllLinks(val, propTypeObj.getProperties(), refs))
         else:
-            rsvLogger.error('{}: complex payload error, @odata.type does not seem to exist in metadata'.format(str(name)))
+            rsvLogger.error('{}: complex payload error, @odata.type does not seem to exist in metadata {}'.format(str(name), val.get('@odata.type')))
 
     for prop in propTypeObj.getProperties():
         propMessages, propCounts, newLinks = checkPropertyConformance(propSoup, prop.name, prop.propDict, val, propRefs,
@@ -1158,7 +1158,7 @@ def main(argv=None, direct_parser=None):
             help='Output debug statements to text log, otherwise it only uses INFO')
     argget.add_argument('--verbose_checks', action="store_const", const=VERBO_NUM, default=logging.INFO,
             help='Show all checks in logging')
-    argget.add_argument('--oemcheck', action='store_true', help='Check OEM items')
+    argget.add_argument('--nooemcheck', action='store_true', help='Don\'t check OEM items')
 
     # service
     argget.add_argument('-i', '--ip', type=str, help='ip to test on [host:port]')

--- a/commonRedfish.py
+++ b/commonRedfish.py
@@ -1,0 +1,35 @@
+# ex: #Power.1.1.1.Power , #Power.v1_0_0.Power
+
+versionpattern = 'v[0-9]_[0-9]_[0-9]'
+def getNamespace(string):
+    if '#' in string:
+        string = string.rsplit('#', 1)[1]
+    return string.rsplit('.', 1)[0]
+
+def getVersion(string):
+    return re.search(versionpattern, item).group()
+
+
+def getNamespaceUnversioned(string):
+    if '#' in string:
+        string = string.rsplit('#', 1)[1]
+    return string.split('.', 1)[0]
+    
+    # alt version concatenation, unused
+    version = getVersion(string) 
+    if version not in [None, '']:
+        return getNamespace(string)
+    return '{}.{}'.format(getNamespace(string), version)
+
+
+def getType(string):
+    if '#' in string:
+        string = string.rsplit('#', 1)[1]
+    return string.rsplit('.', 1)[-1]
+
+
+def createContext(typestring):
+    ns_name = getNamespaceUnversioned(typestring)
+    type_name = getType(typestring)
+    context = '/redfish/v1/$metadata' + '#' + ns_name + '.' + type_name
+    return context

--- a/config.ini
+++ b/config.ini
@@ -13,6 +13,7 @@ CertificateBundle =
 [Options]
 MetadataFilePath = ./SchemaFiles/metadata
 Schema_Pack = 
+OemCheck = On
 CacheMode = Off
 CacheFilePath = 
 SchemaSuffix = _v1.xml

--- a/metadata.py
+++ b/metadata.py
@@ -19,7 +19,7 @@ EDM_TAGS = ['Action', 'Annotation', 'Collection', 'ComplexType', 'EntityContaine
 EDMX_TAGS = ['DataServices', 'Edmx', 'Include', 'Reference']
 
 
-live_zip_uri = 'http://redfish.dmtf.org/schemas/DSP8010_2017.3.zip'
+live_zip_uri = 'http://redfish.dmtf.org/schemas/DSP8010_2018.1.zip'
 
 def setup_schema_pack(uri, local_dir, proxies, timeout):
     rst.traverseLogger.info('Unpacking schema pack...')

--- a/metadata.py
+++ b/metadata.py
@@ -153,7 +153,6 @@ class Metadata(object):
                 name, uri = self.service_refs[schema]
                 result = rst.getSchemaDetails(name, uri)
                 self.schema_store[name] = result
-                
         else:
             logger.warning('Metadata: getSchemaDetails() did not return success')
 

--- a/traverseService.py
+++ b/traverseService.py
@@ -62,7 +62,7 @@ configset = {
         "targetip": str, "username": str, "password": str, "authtype": str, "usessl": bool, "certificatecheck": bool, "certificatebundle": str,
         "metadatafilepath": str, "cachemode": (bool, str), "cachefilepath": str, "schemasuffix": str, "timeout": int, "httpproxy": str, "httpsproxy": str,
         "systeminfo": str, "localonlymode": bool, "servicemode": bool, "token": str, 'linklimit': dict, 'sample': int, 'extrajsonheaders': dict, 'extraxmlheaders': dict, "schema_pack": str,
-        "forceauth": bool
+        "forceauth": bool, "oemcheck": bool
         }
 
 defaultconfig = {

--- a/traverseService.py
+++ b/traverseService.py
@@ -55,7 +55,7 @@ argparse2configparser = {
         'http_proxy': 'httpproxy', 'localonly': 'localonlymode', 'https_proxy': 'httpsproxy', 'passwd': 'password',
         'ip': 'targetip', 'logdir': 'logpath', 'desc': 'systeminfo', 'authtype': 'authtype',
         'payload': 'payloadmode+payloadfilepath', 'cache': 'cachemode+cachefilepath', 'token': 'token',
-        'linklimit': 'linklimit', 'sample': 'sample'
+        'linklimit': 'linklimit', 'sample': 'sample', 'nooemcheck': '!oemcheck'
         } 
 
 configset = {
@@ -66,7 +66,7 @@ configset = {
         }
 
 defaultconfig = {
-        'authtype': 'basic', 'username': "", 'password': "", 'token': '',
+        'authtype': 'basic', 'username': "", 'password': "", 'token': '', 'oemcheck': True,
         'certificatecheck': True, 'certificatebundle': "", 'metadatafilepath': './SchemaFiles/metadata',
         'cachemode': 'Off', 'cachefilepath': './cache', 'schemasuffix': '_v1.xml', 'httpproxy': "", 'httpsproxy': "",
         'localonlymode': False, 'servicemode': False, 'linklimit': {'LogEntry':20}, 'sample': 0, 'schema_pack': None, 'forceauth': False


### PR DESCRIPTION
Adds Complex Dynamic Checking necessary for OEM items, while previously only did Basic types.  (Has an issue with systems with incomplete $metadata, and message spam with MessageRegistries, but seemed to only happen in one given system.)

Don't skip over OEM items and allocate links properly while checking the items.  Add option to enable oemchecks as needed.  (This is done in Validator, but should be handled when constructing our Resource)

Additionally adds some generators for the internal objects

Sans OemCheck:
![capture4](https://user-images.githubusercontent.com/5571676/41125367-e21e46fa-6a69-11e8-9b02-6dd9b324dafd.PNG)

With OemCheck:
![capture2](https://user-images.githubusercontent.com/5571676/41125336-c807e636-6a69-11e8-8511-643c27f66c27.PNG)

Before ComplexCheck:
![image](https://user-images.githubusercontent.com/5571676/41125478-3226ba1a-6a6a-11e8-9220-b84819694b95.png)


After ComplexCheck:
![capture3](https://user-images.githubusercontent.com/5571676/41125391-f15570b2-6a69-11e8-9885-9a7645c65f48.PNG)
