### PR TITLE
Removed exception tracebacks from error messages

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -965,7 +965,7 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
     except AuthenticationError as e:
         raise  # re-raise exception
     except Exception as e:
-        rsvLogger.exception("")  # Printout FORMAT
+        rsvLogger.debug('Exception caught while creating ResourceObj', exc_info=1)
         counts['exceptionResource'] += 1
         results[uriName]['warns'], results[uriName]['errors'] = next(lc)
         return False, counts, results, None, None
@@ -1007,7 +1007,7 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
         except AuthenticationError as e:
             raise  # re-raise exception
         except Exception as ex:
-            rsvLogger.exception("Something went wrong")  # Printout FORMAT
+            rsvLogger.debug('Exception caught while validating single URI', exc_info=1)
             rsvLogger.error('%s: Could not finish check on this property' % (prop.name))  # Printout FORMAT
             counts['exceptionPropCheck'] += 1
 
@@ -1182,7 +1182,7 @@ def main(arglist=None, direct_parser=None):
             cdict = rst.convertConfigParserToDict(direct_parser)
             rst.setConfig(cdict)
         except Exception as ex:
-            rsvLogger.exception("Something went wrong")  # Printout FORMAT
+            rsvLogger.debug('Exception caught while parsing configuration', exc_info=1)
             return 1, None, 'Config Parser Exception'
     elif args.config is None and args.ip is None:
         rsvLogger.info('No ip or config specified.')
@@ -1192,7 +1192,7 @@ def main(arglist=None, direct_parser=None):
         try:
             rst.setByArgparse(args)
         except Exception:
-            rsvLogger.exception("Something went wrong")  # Printout FORMAT
+            rsvLogger.debug('Exception caught while parsing configuration', exc_info=1)
             return 1, None, 'Config Exception'
 
     config = rst.config

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -966,6 +966,8 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
         raise  # re-raise exception
     except Exception as e:
         rsvLogger.debug('Exception caught while creating ResourceObj', exc_info=1)
+        rsvLogger.error('Unable to gather property info for URI {}: {}'
+                        .format(URI, repr(e)))
         counts['exceptionResource'] += 1
         results[uriName]['warns'], results[uriName]['errors'] = next(lc)
         return False, counts, results, None, None
@@ -1183,6 +1185,7 @@ def main(arglist=None, direct_parser=None):
             rst.setConfig(cdict)
         except Exception as ex:
             rsvLogger.debug('Exception caught while parsing configuration', exc_info=1)
+            rsvLogger.error('Unable to parse configuration: {}'.format(repr(ex)))
             return 1, None, 'Config Parser Exception'
     elif args.config is None and args.ip is None:
         rsvLogger.info('No ip or config specified.')
@@ -1191,8 +1194,9 @@ def main(arglist=None, direct_parser=None):
     else:
         try:
             rst.setByArgparse(args)
-        except Exception:
+        except Exception as ex:
             rsvLogger.debug('Exception caught while parsing configuration', exc_info=1)
+            rsvLogger.error('Unable to parse configuration: {}'.format(repr(ex)))
             return 1, None, 'Config Exception'
 
     config = rst.config

--- a/traverseService.py
+++ b/traverseService.py
@@ -1149,8 +1149,9 @@ def getAllLinks(jsonData, propList, schemaObj, prefix='', context='', linklimits
                     else:
                         linkList.update(tp.links)
         traverseLogger.debug(str(linkList))
-    except Exception:
+    except Exception as e:
         traverseLogger.debug('Exception caught while getting all links', exc_info=1)
+        traverseLogger.error('Unexpected error while extracting links from payload: {}'.format(repr(e)))
     # contents of Registries may be needed to validate other resources (like Bios), so move to front of linkList
     if 'Registries.Registries' in linkList:
         linkList.move_to_end('Registries.Registries', last=False)

--- a/traverseService.py
+++ b/traverseService.py
@@ -585,7 +585,7 @@ class PropItem:
                 schemaObj, propOwner, propChild, val, topVersion, customType)
             self.attr = self.propDict['attrs']
         except Exception:
-            traverseLogger.exception("Something went wrong")
+            traverseLogger.debug('Exception caught while creating new PropItem', exc_info=1)
             traverseLogger.error(
                     '{}:{} :  Could not get details on this property'.format(str(propOwner),str(propChild)))
             self.propDict = None
@@ -599,7 +599,7 @@ class PropAction:
             self.propOwner, self.propChild = propOwner, propChild
             self.actTag = act
         except Exception:
-            traverseLogger.exception("Something went wrong")
+            traverseLogger.debug('Exception caught while creating new PropAction', exc_info=1)
             traverseLogger.error(
                     '{}:{} :  Could not get details on this action'.format(str(propOwner),str(propChild)))
             self.actTag = None
@@ -637,7 +637,7 @@ class PropType:
                 if not self.additional:
                     self.additional = self.parent.additional
         except Exception as ex:
-            traverseLogger.exception("Something went wrong")
+            traverseLogger.debug('Exception caught while creating new PropType', exc_info=1)
             traverseLogger.error(
                 '{}:  Getting type failed for {}'.format(str(self.fulltype), str(baseType)))
             raise ex
@@ -1150,7 +1150,7 @@ def getAllLinks(jsonData, propList, schemaObj, prefix='', context='', linklimits
                         linkList.update(tp.links)
         traverseLogger.debug(str(linkList))
     except Exception:
-        traverseLogger.exception("Something went wrong")
+        traverseLogger.debug('Exception caught while getting all links', exc_info=1)
     # contents of Registries may be needed to validate other resources (like Bios), so move to front of linkList
     if 'Registries.Registries' in linkList:
         linkList.move_to_end('Registries.Registries', last=False)


### PR DESCRIPTION
I reran the service validator against the mockups of the systems that showed the tracebacks in the HTML reports. And most of the issues had already been resolved by the fixes @tomasg2012 made a couple of weeks ago (thanks, Tomas).

There were still some traceback errors generated in the HTML reports in places where an exception was caught and an error with traceback was generated via `logger.exception("Something went wrong")`.

I changed those occurrences to only log the traceback in the debug logging and verified that an appropriate error was logged in the HTML report.

Fixes #257 