### PR TITLE
Fixes to minor bugs, missing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ LocalOnlyMode - (boolean) Only test properties against Schema placed in the root
 
 ServiceMode - (boolean) Only test properties against Resources/Schema that exist on the Service
 
-PreferOnline - (boolean) Prefer online/service schema over local schema 
+PreferOnline - (boolean) Prefer online/service schema over local schema.  This will also disable downloading all schema to specified metadata directory 
 
 MetadataFilePath - (string) This attribute points to the location of the DMTF schema file location, populated by xml files
 
@@ -128,6 +128,7 @@ To run unittests, use the command:
 ## Execution flow
 
 1. Redfish Service Validator starts with the Service root Resource Schema by querying the service with the service root URI and getting all the device information, the resources supported and their links. Once the response of the Service root query is verified against its schema, the tool traverses through all the collections and Navigation properties returned by the service.
+    * From the Metadata, collect all XML specified possible from the service, and store them in a tool-specified directory
 2. For each navigation property/Collection of resource returned, it does following operations:
     * Reads all the Navigation/collection of resources from the respective resource collection schema file.
     * Reads the schema file related to the particular resource, collects all the information about individual properties from the resource schema file and stores them into a dictionary

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1013,7 +1013,6 @@ def validateSingleURI(URI, uriName='', expectedType=None, expectedSchema=None, e
                 counts['badOdataIdResolution'] += 1
         else:
             rsvLogger.warn('No parent found with which to test @odata.id of ReferenceableMember')
-            input('??')
 
     if not successPayload:
         counts['failPayloadError'] += 1

--- a/commonRedfish.py
+++ b/commonRedfish.py
@@ -1,5 +1,10 @@
+# Copyright Notice:
+# Copyright 2016-2018 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Service-Validator/blob/master/LICENSE.md
 
 import re
+import traverseService as rst
+
 
 """
  Power.1.1.1.Power , Power.v1_0_0.Power
@@ -9,6 +14,7 @@ versionpattern = 'v[0-9]_[0-9]_[0-9]'
 
 
 def navigateJsonFragment(decoded, URILink):
+    traverseLogger = rst.getLogger()
     if '#' in URILink:
         URILink, frag = tuple(URILink.rsplit('#', 1))
         fragNavigate = frag.split('/')
@@ -40,6 +46,7 @@ def getNamespace(string: str):
     if '#' in string:
         string = string.rsplit('#', 1)[1]
     return string.rsplit('.', 1)[0]
+
 
 def getVersion(string: str):
     """getVersion

--- a/metadata.py
+++ b/metadata.py
@@ -19,7 +19,7 @@ EDM_TAGS = ['Action', 'Annotation', 'Collection', 'ComplexType', 'EntityContaine
 EDMX_TAGS = ['DataServices', 'Edmx', 'Include', 'Reference']
 
 
-live_zip_uri = 'http://redfish.dmtf.org/schemas/DSP8010_2018.1.zip'
+live_zip_uri = 'http://redfish.dmtf.org/schemas/DSP8010_2018.2.zip'
 
 
 def setup_schema_pack(uri, local_dir, proxies, timeout):

--- a/simpletypes.py
+++ b/simpletypes.py
@@ -7,9 +7,10 @@ import traverseService as rst
 
 rsvLogger = rst.getLogger()
 
+
 def validateDeprecatedEnum(name: str, val, listEnum: list):
     """validateDeprecatedEnum
-    
+
     Validates a DeprecatedEnum
 
     :param name: Name of property (printing purposes) Property Name
@@ -75,7 +76,7 @@ def validateString(name: str, val, pattern=None):
             match = re.fullmatch(pattern, val)
             paramPass = match is not None
             if not paramPass:
-                rsvLogger.error("{}: String '{}' does not match pattern '{}'".format(name, str(val), str(pattern)))
+                rsvLogger.error("{}: String '{}' does not match pattern '{}'".format(name, str(val), repr(pattern)))
         else:
             paramPass = True
     else:
@@ -85,7 +86,7 @@ def validateString(name: str, val, pattern=None):
 
 def validateDatetime(name: str, val):
     """validateDatetime
-    
+
     Validates a Datetime, given a value (pattern predetermined)
 
     :param name: Name of property (printing purposes)
@@ -133,7 +134,7 @@ def validateInt(name: str, val, minVal=None, maxVal=None):
 
 def validateNumber(name: str, val, minVal=None, maxVal=None):
     """validateNumber
-    
+
     Validates a Number and its min/max values
 
     :param name: Name of property (printing purposes)

--- a/tests/complexeval.py
+++ b/tests/complexeval.py
@@ -14,7 +14,7 @@ sys.path.append('../')
 
 import json, os
 import traverseService as rst
-import RedfishServiceValidator as rsv 
+import RedfishServiceValidator as rsv
 from bs4 import BeautifulSoup
 
 rsvLogger = rst.getLogger()
@@ -28,30 +28,30 @@ class ValidatorTest(TestCase):
     """
     def test_example(self):
         with open('tests/testdata/payloads/simple.json') as f:
-            example_json = json.load(f) 
-        
+            example_json = json.load(f)
+
         rsc = rst.ResourceObj('test', 'test', example_json, None, None, None, False)
-        for prop in rsc.getResourceProperties(): 
-                propMessages, propCounts = rsv.checkPropertyConformance(rsc.schemaObj, prop.name, prop.propDict, rsc.jsondata, parentURI='')
+        for prop in rsc.getResourceProperties():
+                propMessages, propCounts = rsv.checkPropertyConformance(rsc.schemaObj, prop.name, prop, rsc.jsondata, parentURI='')
                 print(propMessages)
                 print(propCounts)
 
     def test_example_bad(self):
         with open('tests/testdata/payloads/simple_bad.json') as f:
-            example_json = json.load(f) 
-        
+            example_json = json.load(f)
+
         rsc = rst.ResourceObj('test', 'test', example_json, None, None, None, False)
-        for prop in rsc.getResourceProperties(): 
-                propMessages, propCounts = rsv.checkPropertyConformance(rsc.schemaObj, prop.name, prop.propDict, rsc.jsondata, parentURI='')
+        for prop in rsc.getResourceProperties():
+                propMessages, propCounts = rsv.checkPropertyConformance(rsc.schemaObj, prop.name, prop, rsc.jsondata, parentURI='')
                 print(propMessages)
                 print(propCounts)
 
     def test_example_complex(self):
         with open('tests/testdata/payloads/simple_complex.json') as f:
-            example_json = json.load(f) 
-        
+            example_json = json.load(f)
+
         rsc = rst.ResourceObj('test', 'test', example_json, None, None, None, False)
-        for prop in rsc.getResourceProperties(): 
-                propMessages, propCounts = rsv.checkPropertyConformance(rsc.schemaObj, prop.name, prop.propDict, rsc.jsondata, parentURI='')
+        for prop in rsc.getResourceProperties():
+                propMessages, propCounts = rsv.checkPropertyConformance(rsc.schemaObj, prop.name, prop, rsc.jsondata, parentURI='')
                 print(propMessages)
                 print(propCounts)

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -13,8 +13,8 @@ import os
 
 sys.path.append('../')
 
-import rfSchema
 import traverseService as rst
+import rfSchema
 from bs4 import BeautifulSoup
 
 rsvLogger = rst.getLogger()
@@ -77,7 +77,7 @@ class SchemaTest(TestCase):
         self.assertTrue(rfo.getTypeTagInSchema('Example') is not None)
 
     def test_get_parent_type(self):
-        # todo: consider unusual parent situations (?) 
+        # todo: consider unusual parent situations (?)
         rfo = rfSchema.getSchemaObject('Example.Example', '/redfish/v1/$metadata#Example.Example')
         assert rfo
 

--- a/traverseService.py
+++ b/traverseService.py
@@ -18,7 +18,7 @@ import configparser
 from urllib.parse import urlparse, urlunparse
 
 import metadata as md
-from commonRedfish import createContext, getNamespace, getNamespaceUnversioned, getType, getVersion, navigateJsonFragment
+from commonRedfish import createContext, getNamespace, getNamespaceUnversioned, getType, navigateJsonFragment
 import rfSchema
 
 traverseLogger = logging.getLogger(__name__)
@@ -86,6 +86,7 @@ defaultconfig = {
         'preferonline': False,
         'linklimit': {'LogEntry': 20},
         'sample': 0,
+        'usessl': True,
         'timeout': 30,
         'schema_pack': None,
         'forceauth': False,
@@ -105,6 +106,7 @@ customval = {
 configSet = False
 
 config = dict(defaultconfig)
+
 
 def startService(config, defaulted=[]):
     """startService
@@ -297,6 +299,8 @@ class rfService():
         # with Version, get default and compare to user defined values
         default_config_target = defaultconfig_by_version.get(target_version, dict())
         override_with = {k: default_config_target[k] for k in default_config_target if k in default_entries}
+        if len(override_with) > 0:
+            traverseLogger.info('CONFIG: RedfishVersion {} has augmented these tool defaults {}'.format(target_version, override_with))
         self.config.update(override_with)
 
         self.active = True
@@ -535,7 +539,7 @@ def createResourceObject(name, uri, jsondata=None, typename=None, context=None, 
     # Get Schema object
     schemaObj = rfSchema.getSchemaObject(acquiredtype, context)
     if schemaObj is None:
-        traverseLogger.error("ResourceObject creation: No schema XML for {} {} {}".format(typename, acquiredtype, context))
+        traverseLogger.error("ResourceObject creation: No schema XML for {} {}".format(acquiredtype, context))
         return None
 
     forceType = False


### PR DESCRIPTION
Added automatic file cacheing of XMLs pulled from DMTF/Service

Added proper message for navigating links to Entities with incorrect types

Verify an odata_id with a fragment properly resolves to itself, via its parent

Properly start from '/redfish/v1/' instead of '/redfish/v1'

Add missing license comments

Fixed missing logger in commonRedfish

Updated current schema_pack zip to latest 2018.2

Removed stripping from Redfish.Uris checking (compareUri)

Fixed missing default option for usessl

Print verbosely what options overwritten for RedfishVersion protocol

Minor code reformatting (pep8, unused lines)