### PR TITLE
Improve error message for HTTP GET uri failures

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -186,7 +186,8 @@ def validateEntity(name: str, val: dict, propType: str, propCollectionType: str,
         else:
             rsvLogger.error("{}: Could not get schema file for Entity check".format(name))
     else:
-        rsvLogger.error("{}: Could not get resource for Entity check".format(name))
+        rsvLogger.error("{}: GET of resource at URI {} returned HTTP {}. Check URI."
+                        .format(name, uri, status if isinstance(status, int) and status >= 200 else "error"))
     return paramPass
 
 


### PR DESCRIPTION
Per comment by @jautor in #317, updated error to be more helpful.

Before:

```
ERROR - MetricReport: Could not get resource for Entity check
```

After:

```
ERROR - MetricReport: GET of resource at URI /redfish/v1/TelemetryService/MetricReportsCPUUtilCustom1/ returned HTTP 404. Check URI.
```

Fixes #317 