### PR TITLE
Remove warning for @odata.etag properties

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -928,6 +928,8 @@ def checkPayloadConformance(uri, decoded, ParentItem=None):
             paramPass = isinstance(decoded[key], str)
             if paramPass:
                 paramPass = re.fullmatch('#([a-zA-Z0-9_.-]*\.)+[a-zA-Z0-9_.-]*', decoded[key]) is not None
+        elif annotation == '@odata.etag':
+            paramPass = True
         else:
             rsvLogger.warn(prefix + key + " @odata item not checked: " + str(decoded[key]))
             paramPass = True


### PR DESCRIPTION
Per issue #320, eliminate WARNING for @odata.etag properties.

Fixes #320 