### PR TITLE
Allow OperationApplyTimeSupport in Actions

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -85,8 +85,8 @@ def validateActions(name: str, val: dict, propTypeObj: rst.rfSchema.PropType, pa
                 if prop not in ['target', 'title', '@Redfish.ActionInfo',
                                 '@Redfish.OperationApplyTimeSupport'] and '@Redfish.AllowableValues' not in prop:
                     actPass = False
-                    rsvLogger.error('{}: Property "{}" is not allowed in actions property. Allowed properties are "{}", "{}", "{}" and "{}"'
-                            .format(name + '.' + k, prop, 'target', 'title', '@Redfish.ActionInfo', '*@Redfish.AllowableValues'))
+                    rsvLogger.error('{}: Property "{}" is not allowed in actions property. Allowed properties are "{}", "{}", "{}", "{}" and "{}"'
+                            .format(name + '.' + k, prop, 'target', 'title', '@Redfish.ActionInfo', '@Redfish.OperationApplyTimeSupport', '*@Redfish.AllowableValues'))
         else:
             # <Annotation Term="Redfish.Required"/>
             if actDict is not None and actDict.find('annotation', {'term': 'Redfish.Required'}):

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -82,7 +82,8 @@ def validateActions(name: str, val: dict, propTypeObj: rst.rfSchema.PropType, pa
                                     .format(name + '.' + k, str(type(target)).strip('<>')))
                 # check for unexpected properties
             for prop in actionDecoded:
-                if prop not in ['target', 'title', '@Redfish.ActionInfo'] and '@Redfish.AllowableValues' not in prop:
+                if prop not in ['target', 'title', '@Redfish.ActionInfo',
+                                '@Redfish.OperationApplyTimeSupport'] and '@Redfish.AllowableValues' not in prop:
                     actPass = False
                     rsvLogger.error('{}: Property "{}" is not allowed in actions property. Allowed properties are "{}", "{}", "{}" and "{}"'
                             .format(name + '.' + k, prop, 'target', 'title', '@Redfish.ActionInfo', '*@Redfish.AllowableValues'))


### PR DESCRIPTION
Updated validation logic for Actions to allow the (relatively) new @Redfish.OperationApplyTimeSupport annotation.

Fixes #340  