### PR TITLE
Updates to support 2019.2 versioning and schemapack

### DIFF
--- a/commonRedfish.py
+++ b/commonRedfish.py
@@ -26,7 +26,7 @@ def splitVersionString(version):
         payload_split = v_payload.split('.')
     if len(payload_split) != 3:
         return [1, 0, 0]
-    return payload_split
+    return [int(v) for v in payload_split]
 
 
 def compareMinVersion(version, min_version):
@@ -38,18 +38,8 @@ def compareMinVersion(version, min_version):
     min_split = splitVersionString(min_version)
     payload_split = splitVersionString(version)
 
-    paramPass = True
-    for a, b in zip(min_split, payload_split):
-        b = 0 if b is None else int(b)
-        a = 0 if a is None else int(a)
-        if (b > a):
-            break
-        if (b < a):
-            paramPass = False
-            break
-
-    # use string comparison, given version numbering is accurate to regex
-    return paramPass
+    # use array comparison, which compares each sequential number
+    return min_split <= payload_split
 
 def navigateJsonFragment(decoded, URILink):
     traverseLogger = rst.getLogger()

--- a/metadata.py
+++ b/metadata.py
@@ -19,13 +19,13 @@ EDM_TAGS = ['Action', 'Annotation', 'Collection', 'ComplexType', 'EntityContaine
 EDMX_TAGS = ['DataServices', 'Edmx', 'Include', 'Reference']
 
 
-live_zip_uri = 'http://redfish.dmtf.org/schemas/DSP8010_2019.1.zip'
+live_zip_uri = 'http://redfish.dmtf.org/schemas/DSP8010_2019.2.zip'
 
 
 def setup_schema_pack(uri, local_dir, proxies, timeout):
-    rst.traverseLogger.info('Unpacking schema pack...')
     if uri == 'latest':
         uri = live_zip_uri
+    rst.traverseLogger.info('Unpacking schema pack... {}'.format(uri))
     try:
         if not os.path.isdir(local_dir):
             os.makedirs(local_dir)


### PR DESCRIPTION
Correctly addresses versions above a single digit size.

Fixes #349 

