### PR TITLE
Explicit checks to typechain for property version validation

### DIFF
--- a/commonRedfish.py
+++ b/commonRedfish.py
@@ -25,7 +25,7 @@ def splitVersionString(version):
     else:
         payload_split = v_payload.split('.')
     if len(payload_split) != 3:
-        return [1, 0, 0]
+        return [0, 0, 0]
     return [int(v) for v in payload_split]
 
 
@@ -39,7 +39,7 @@ def compareMinVersion(version, min_version):
     payload_split = splitVersionString(version)
 
     # use array comparison, which compares each sequential number
-    return min_split <= payload_split
+    return min_split < payload_split
 
 def navigateJsonFragment(decoded, URILink):
     traverseLogger = rst.getLogger()

--- a/rfSchema.py
+++ b/rfSchema.py
@@ -350,7 +350,7 @@ class rfSchema:
             if limit is not None:
                 if getVersion(newNamespace) is None:
                     continue
-                if compareMinVersion(limit, newNamespace):
+                if compareMinVersion(newNamespace, limit):
                     continue
             if schema.find(['EntityType', 'ComplexType'], attrs={'Name': getType(acquiredtype)}, recursive=False):
                 typelist.append(splitVersionString(newNamespace))
@@ -639,8 +639,10 @@ class PropItem:
             self.name = propOwner + ':' + propChild
             self.propOwner, self.propChild = propOwner, propChild
             self.val = val
-            self.valid = topVersion is None or \
-                    compareMinVersion(topVersion, propOwner)
+            self.valid = topVersion is None or\
+                    compareMinVersion(topVersion, propOwner) or\
+                    topVersion == propOwner or\
+                    getVersion(topVersion) == getVersion(propOwner)
             self.exists = val != 'n/a'
             self.payloadName = payloadName if payloadName is not None else propChild
             self.propDict = getPropertyDetails(

--- a/rfSchema.py
+++ b/rfSchema.py
@@ -470,7 +470,11 @@ class PropType:
             # if our val is empty, do fuzzy check for property that exists in payload but not in all properties
             if val == 'n/a':
                 pname = get_fuzzy_property(newProp, jsondata, allPropList)
-            props.append(PropItem(schemaObj, newPropOwner, newProp, val, topVersion, payloadName=pname))
+            validTypes = [getNamespace(x) for x in self.getTypeChain()]
+            if (topVersion in validTypes):
+                validTypes = validTypes[validTypes.index(topVersion):]
+            props.append(PropItem(schemaObj, newPropOwner, newProp, val, topVersion, payloadName=pname, versionList=validTypes))
+
 
         return props
 
@@ -634,15 +638,14 @@ def getTypeObject(typename, schemaObj):
 
 
 class PropItem:
-    def __init__(self, schemaObj, propOwner, propChild, val, topVersion=None, customType=None, payloadName=None):
+    def __init__(self, schemaObj, propOwner, propChild, val, topVersion=None, customType=None, payloadName=None, versionList=None):
         try:
             self.name = propOwner + ':' + propChild
             self.propOwner, self.propChild = propOwner, propChild
             self.val = val
             self.valid = topVersion is None or\
-                    compareMinVersion(topVersion, propOwner) or\
-                    topVersion == propOwner or\
-                    getVersion(topVersion) == getVersion(propOwner)
+                    versionList is None or\
+                    (getNamespace( propOwner ) in versionList)
             self.exists = val != 'n/a'
             self.payloadName = payloadName if payloadName is not None else propChild
             self.propDict = getPropertyDetails(


### PR DESCRIPTION
previous:
```
*** /redfish/v1/Chassis                                                                                                                                                   
         Type (#ChassisCollection.ChassisCollection), GET SUCCESS (time: 0.003215)                                                                                        
Verifying property that does not belong to this version: Resource.v1_0_0.ResourceCollection:Description                                                                   
Verifying property that does not belong to this version: Resource.v1_0_0.ResourceCollection:Name                                                                          
          FAIL... 
```
new:
```
*** /redfish/v1/Chassis                      
         Type (#ChassisCollection.ChassisCollection), GET SUCCESS (time: 0.042388)
         PASS       
*** /redfish/v1/Chassis/1U
         Type (#Chassis.v1_0_0.Chassis), GET SUCCESS (time: 0.022069)
Verifying property that does not belong to this version: Chassis.v1_10_0.Chassis:PCIeDevices
Verifying property that does not belong to this version: Chassis.v1_4_0.Chassis:HeightMm
Verifying property that does not belong to this version: Chassis.v1_4_0.Chassis:WidthMm
Verifying property that does not belong to this version: Chassis.v1_4_0.Chassis:DepthMm
Verifying property that does not belong to this version: Chassis.v1_4_0.Chassis:WeightKg
Verifying property that does not belong to this version: Chassis.v1_2_0.Chassis:Location
Verifying property that does not belong to this version: Chassis.v1_0_1.Chassis:PowerState
          FAIL...
```