### PR TITLE
Added missing allowance for Resource.Resource or generic links

### DIFF
--- a/commonValidator.py
+++ b/commonValidator.py
@@ -106,7 +106,7 @@ def validateEntity(name: str, val: dict, propType: str, propCollectionType: str,
     rsvLogger.debug('(success, uri, status, delay) = {}, (propType, propCollectionType) = {}, data = {}'
                     .format((success, uri, status, delay), (propType, propCollectionType), data))
     # if the reference is a Resource, save us some trouble as most/all basetypes are Resource
-    generics = ['Resource.ItemOrCollection', 'Resource.ResourceCollection', 'Resource.Item']
+    generics = ['Resource.ItemOrCollection', 'Resource.ResourceCollection', 'Resource.Item', 'Resource.Resource']
     if (propCollectionType in generics or propType in generics) and success:
         return True
     elif success:


### PR DESCRIPTION
Without this fix, Navigation Properties like "EntityLink" in Endpoint would fail since the tool is explicitly looking for a resource of type "Resource.Resource" instead of allowing for any type of resource.