### PR TITLE
Add requests.Session to optimize HTTP connection time

### DIFF
--- a/traverseService.py
+++ b/traverseService.py
@@ -251,6 +251,9 @@ class rfService():
         self.proxies = dict()
         self.active = False
 
+        # Create a Session to optimize connection times
+        self.session = requests.Session()
+
         config['configuri'] = ('https' if config.get('usessl', True) else 'http') + '://' + config['targetip']
         httpprox = config['httpproxy']
         httpsprox = config['httpsproxy']
@@ -408,7 +411,7 @@ class rfService():
         try:
             if payload is not None and CacheMode == 'Prefer':
                 return True, payload, -1, 0
-            response = requests.get(URLDest,
+            response = self.session.get(URLDest,
                                     headers=headers, auth=auth, verify=certVal, timeout=timeout,
                                     proxies=proxies if not inService else None)  # only proxy non-service
             expCode = [200]


### PR DESCRIPTION
Creating a Session will allow us to persist certain connection parameters across requests thereby making them faster.
There is a detailed analysis in here: https://stackoverflow.com/questions/32986228/difference-between-using-requests-get-and-requests-session-get
The following sample snapshot shows amount of time saved by this addition,
![image](https://user-images.githubusercontent.com/11836146/122587971-23cb9a00-d07c-11eb-8c55-8e8a9e3a1bd3.png)
