### PR TITLE
Move schemapack default to 2021.2

### DIFF
--- a/schema_pack.py
+++ b/schema_pack.py
@@ -10,7 +10,7 @@ import zipfile
 import requests
 
 # live_zip_uri = 'http://redfish.dmtf.org/schemas/DSP8010_2021.1.zip'
-live_zip_uri = 'https://www.dmtf.org/sites/default/files/standards/documents/DSP8010_2021.1.zip' 
+live_zip_uri = 'https://www.dmtf.org/sites/default/files/standards/documents/DSP8010_2021.2.zip' 
 
 my_logger = logging.getLogger()
 

--- a/schema_pack.py
+++ b/schema_pack.py
@@ -10,7 +10,7 @@ import zipfile
 import requests
 
 # live_zip_uri = 'http://redfish.dmtf.org/schemas/DSP8010_2021.1.zip'
-live_zip_uri = 'https://www.dmtf.org/sites/default/files/standards/documents/DSP8010_2021.2.zip' 
+live_zip_uri = 'https://www.dmtf.org/sites/default/files/standards/documents/DSP8010.zip' 
 
 my_logger = logging.getLogger()
 


### PR DESCRIPTION
Fix #422 

2021.2 was released yesterday, Sept 22nd.

Move the schemapack default (i.e. if --source not given) to 2021.2

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>