### PR TITLE
Add URI checking and Capabilities checking, small bug tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Variable   | Type   | Definition
 Version    | string | Internal config version (optional)
 Copyright  | string | _DMTF_ copyright (optional)
 verbose    | int    | level of verbosity (0-3) 
+
 ### [Host]
+
 Variable   | Type    | Definition
 --         |--       |--
 ip         | string  | Host of testing system, formatted as https:// ip : port (can use http as well)
@@ -56,15 +58,18 @@ authtype   | string  | Authorization type (Basic | Session | Token | None)
 token      | string  | Token string for Token authentication
 
 ### [Validator]
+
 Variable        | Type    | Definition
 --              |--       |--
 payload         | string  | Option to test a specific payload or resource tree (see below)
 logdir          | string  | Place to save logs and run configs
 oemcheck        | boolean | Whether to check Oem items on service
+uricheck        | boolean | Allow URI checking on services below RedfishVersion 1.6.0
 debugging       | boolean | Whether to print debug to log
 schema_directory| string  | Where schema is located/saved on system
 
 ### Payload options
+
 The payload option takes two parameters as "option uri"
 
 (Single, SingleFile, Tree, TreeFile)

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -46,6 +46,7 @@ def main(argslist=None, configfile=None):
     argget.add_argument('--logdir', type=str, default='./logs', help='directory for log files')
     argget.add_argument('--nooemcheck', action='store_false', dest='oemcheck', help='Don\'t check OEM items')
     argget.add_argument('--debugging', action="store_true", help='Output debug statements to text log, otherwise it only uses INFO')
+    argget.add_argument('--uricheck', action="store_true", help='Allow URI checking on services below RedfishVersion 1.6.0')
     argget.add_argument('--schema_directory', type=str, default='./SchemaFiles/metadata', help='directory for local schema files')
 
     # parse...
@@ -120,7 +121,7 @@ def main(argslist=None, configfile=None):
 
     import common.traverse as traverse
     try:
-        currentService = traverse.startService(vars(args))
+        currentService = traverse.rfService(vars(args))
     except Exception as ex:
         my_logger.log(logging.INFO-1, 'Exception caught while creating Service', exc_info=1)
         my_logger.error("Service could not be started: {}".format(repr(ex)))

--- a/RedfishServiceValidatorGui.py
+++ b/RedfishServiceValidatorGui.py
@@ -78,6 +78,10 @@ g_config_defaults = {
             "value": "False",
             "description": "Whether to print debug to log"
         },
+        "uricheck": {
+            "value": "False",
+            "description": "Whether to force urichecking if under RedfishVersion 1.6.0"
+        },
         "schema_directory": {
             "value": "./SchemaFiles/metadata",
             "description": "Where schema is located/saved on system"

--- a/common/catalog.py
+++ b/common/catalog.py
@@ -801,6 +801,9 @@ class RedfishObject(RedfishProperty):
         if isinstance(payload, list):
             payloads = payload
         for load in payloads:
+            if load is None:
+                # If the object is null, treat it as an empty object for the cataloging
+                load = {}
             sub_obj = copy.copy(eval_obj)
 
             # Cast types if they're below their parent or are OemObjects

--- a/common/catalog.py
+++ b/common/catalog.py
@@ -789,7 +789,7 @@ class RedfishObject(RedfishProperty):
 
         if payload == REDFISH_ABSENT:
             eval_obj.Collection = []
-            eval_obj.IsValid = eval_obj.Type.IsMandatory
+            eval_obj.IsValid = eval_obj.Type.IsNullable
             eval_obj.HasValidUri = True
             eval_obj.properties = {x:y.populate(REDFISH_ABSENT) for x, y in eval_obj.properties.items()}
             return eval_obj

--- a/common/config.py
+++ b/common/config.py
@@ -11,7 +11,7 @@ my_logger.setLevel(logging.DEBUG)
 config_struct = {
     'Tool': ['verbose'],
     'Host': ['ip', 'username', 'password', 'description', 'forceauth', 'authtype', 'token'],
-    'Validator': ['payload', 'logdir', 'oemcheck', 'debugging', 'schema_directory']
+    'Validator': ['payload', 'logdir', 'oemcheck', 'debugging', 'schema_directory', 'uricheck']
 }
 
 config_options = [x for name in config_struct for x in config_struct[name]]

--- a/common/helper.py
+++ b/common/helper.py
@@ -39,8 +39,8 @@ def splitVersionString(version):
     else:
         payload_split = v_payload.split('.')
     if len(payload_split) != 3:
-        return [0, 0, 0]
-    return [int(v) for v in payload_split]
+        return tuple([0, 0, 0])
+    return tuple([int(v) for v in payload_split])
 
 
 def compareMinVersion(version, min_version):
@@ -53,7 +53,7 @@ def compareMinVersion(version, min_version):
     payload_split = splitVersionString(version)
 
     # use array comparison, which compares each sequential number
-    return min_split < payload_split
+    return min_split <= payload_split
 
 
 def navigateJsonFragment(decoded, URILink):

--- a/common/schema.py
+++ b/common/schema.py
@@ -75,7 +75,7 @@ def getSchemaDetails(service, SchemaType, SchemaURI):
             base_schema_uri, frag = tuple(SchemaURI.rsplit('#', 1))
         else:
             base_schema_uri, frag = SchemaURI, None
-        success, data, status, elapsed = service.callResourceURI(base_schema_uri)
+        success, data, response, elapsed = service.callResourceURI(base_schema_uri)
         if success:
             soup = BeautifulSoup(data, "xml")
             # if frag, look inside xml for real target as a reference

--- a/common/traverse.py
+++ b/common/traverse.py
@@ -42,7 +42,7 @@ class rfService():
         self.config['certificatebundle'] = None
         self.config['timeout'] = 10
 
-        self.catalog = catalog.SchemaCatalog('./SchemaFiles/metadata/')
+        self.catalog = catalog.SchemaCatalog(self.config['metadatafilepath'])
 
         if not self.config['usessl'] and not self.config['forceauth']:
             if self.config['username'] not in ['', None] or self.config['password'] not in ['', None]:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -24,6 +24,7 @@ class TestCatalog(unittest.TestCase):
         self.assertEqual(val, 'PropertyA')
         val = catalog.get_fuzzy_property('PropertyA', {'Name': 'Payload'}, ['PropertyB'])
         self.assertEqual(val, 'PropertyA')
+        # OK
 
     def test_catalog(self):
         print('\n')
@@ -38,6 +39,7 @@ class TestCatalog(unittest.TestCase):
         my_type = my_catalog.getTypeInCatalog('Example.v1_7_0.Example')
 
         my_type = my_catalog.getTypeInCatalog('Example.v1_2_0.Links')
+        # OK
     
     def test_schema_doc(self):
         print('\n')
@@ -66,7 +68,7 @@ class TestCatalog(unittest.TestCase):
         my_schema = my_catalog.getSchemaInCatalog('Example.v1_0_0')
     
     def test_basic_properties(self):
-        print('\n')
+        print('\nTesting basic types as json')
         prop = catalog.RedfishProperty("Edm.Int").populate(1)
         print(prop.as_json())
         prop = catalog.RedfishProperty("Edm.Decimal").populate(1.1)
@@ -77,19 +79,19 @@ class TestCatalog(unittest.TestCase):
         print(prop.as_json())
 
     def test_basic_properties_check(self):
-        print('\n')
+        print('\nTesting check values')
         prop = catalog.RedfishProperty("Edm.Int").populate(1, check=True)
         prop = catalog.RedfishProperty("Edm.Int").populate(1.1, check=True)
         prop = catalog.RedfishProperty("Edm.Int").populate("1", check=True)
         prop = catalog.RedfishProperty("Edm.Decimal").populate(1.1, check=True)
         prop = catalog.RedfishProperty("Edm.Decimal").populate("1.1", check=True)
-        prop = catalog.RedfishProperty("Edm.String").populate("1")
-        prop = catalog.RedfishProperty("Edm.String").populate(1)
+        prop = catalog.RedfishProperty("Edm.String").populate("1", check=True)
+        prop = catalog.RedfishProperty("Edm.String").populate(1, check=True)
         prop = catalog.RedfishProperty("Edm.Guid").populate("123", check=True)
         prop = catalog.RedfishProperty("Edm.Guid").populate(catalog.REDFISH_ABSENT, check=True)
     
     def test_object(self):
-        print('\n')
+        print('\nTesting object values')
         my_catalog = catalog.SchemaCatalog('./tests/testdata/schemas/')
         my_schema_doc = my_catalog.getSchemaDocByClass("ExampleResource.v1_0_0.ExampleResource")
         my_type = my_schema_doc.getTypeInSchemaDoc("ExampleResource.v1_0_0.ExampleResource")
@@ -101,6 +103,40 @@ class TestCatalog(unittest.TestCase):
         pprint.pprint(object.as_json(), indent=2)
         dct = object.as_json()
         dct = object.getLinks()
+    
+    def test_expected_uris(self):
+        print('\nTesting expected Uris')
+        my_catalog = catalog.SchemaCatalog('./tests/testdata/schemas/')
+        my_schema_doc = my_catalog.getSchemaDocByClass("Example.v1_0_0.Example")
+        my_type = my_schema_doc.getTypeInSchemaDoc("Example.v1_0_0.Example")
+        object = catalog.RedfishObject( my_type )
+        arr = object.Type.getUris()
+        self.assertEqual(len(arr), 2)
+        object = catalog.RedfishObject( my_type ).populate({
+            "@odata.id": "/redfish/v1/Example",
+            "Id": None,
+            "Description": None
+            })
+        print(object.HasValidUri)
+        object = catalog.RedfishObject( my_type ).populate({
+            "@odata.id": "/redfish/v1/Examples",
+            "Id": None,
+            "Description": None
+            })
+        print(object.HasValidUri)
+        object = catalog.RedfishObject( my_type ).populate({
+            "@odata.id": "/redfish/v1/Examples/FunnyID",
+            "Id": None,
+            "Description": None
+            })
+        print(object.HasValidUri)
+        object = catalog.RedfishObject( my_type ).populate({
+            "@odata.id": "/redfish/v1/Example/NoId",
+            "Id": None,
+            "Description": None
+            })
+        print(object.HasValidUri)
+
 
 
 if __name__ == '__main__':

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -103,6 +103,15 @@ class TestCatalog(unittest.TestCase):
         pprint.pprint(object.as_json(), indent=2)
         dct = object.as_json()
         dct = object.getLinks()
+
+    def test_capabilities(self):
+        my_catalog = catalog.SchemaCatalog('./tests/testdata/schemas/')
+        my_schema_doc = my_catalog.getSchemaDocByClass("Example.v1_0_0.Example")
+        my_type = my_schema_doc.getTypeInSchemaDoc("Example.v1_0_0.Example")
+        print(my_type.getCapabilities())
+        print(my_type.CanUpdate)
+        print(my_type.CanInsert)
+        print(my_type.CanDelete)
     
     def test_expected_uris(self):
         print('\nTesting expected Uris')
@@ -125,13 +134,13 @@ class TestCatalog(unittest.TestCase):
             })
         print(object.HasValidUri)
         object = catalog.RedfishObject( my_type ).populate({
-            "@odata.id": "/redfish/v1/Examples/FunnyID",
-            "Id": None,
+            "@odata.id": "/redfish/v1/Examples/FunnyId",
+            "Id": 'FunnyId',
             "Description": None
             })
         print(object.HasValidUri)
         object = catalog.RedfishObject( my_type ).populate({
-            "@odata.id": "/redfish/v1/Example/NoId",
+            "@odata.id": "/redfish/v1/Examples/NoId",
             "Id": None,
             "Description": None
             })

--- a/tests/testdata/schemas/Example_v1.xml
+++ b/tests/testdata/schemas/Example_v1.xml
@@ -49,7 +49,7 @@
         <Annotation Term="Redfish.Uris">
           <Collection>
             <String>/redfish/v1/Example</String>
-            <String>/redfish/v1/Examples/{Id}</String>
+            <String>/redfish/v1/Examples/{ExampleId}</String>
           </Collection>
         </Annotation>
       </EntityType>

--- a/tests/testdata/schemas/Example_v1.xml
+++ b/tests/testdata/schemas/Example_v1.xml
@@ -46,6 +46,12 @@
             <PropertyValue Property="Deletable" Bool="false"/>
           </Record>
         </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Example</String>
+            <String>/redfish/v1/Examples/{Id}</String>
+          </Collection>
+        </Annotation>
       </EntityType>
 
       <Action Name="ExampleAction" IsBound="true">
@@ -100,7 +106,7 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.Required"/>
         </Property>
-        <Property Name="Status" Type="ExampleExampleResource.Status" Nullable="false"/>
+        <Property Name="Status" Type="ExampleResource.Status" Nullable="false"/>
         <Property Name="cString" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
         </Property>
@@ -133,7 +139,7 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.Required"/>
         </Property>
-        <Property Name="Status" Type="ExampleExampleResource.Status" Nullable="false"/>
+        <Property Name="Status" Type="ExampleResource.Status" Nullable="false"/>
         <Property Name="pString" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
         </Property>
@@ -177,35 +183,11 @@
         <Property Name="ComplexInner" Type="Example.v1_0_0.ComplexInner" Nullable="false">
         </Property>
 
-        <NavigationProperty Name="LogServices" Type="LogServiceCollection.LogServiceCollection" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the logs for this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a collection of type LogServiceCollection."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Thermal" Type="Thermal.Thermal" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the thermal properties (fans, cooling, sensors) of this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a reference to the resource that represents the thermal characteristics of this chassis and shall be of type Thermal."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Power" Type="Power.Power" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the power properties (power supplies, power policies, sensors) of this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a reference to the resource that represents the power characteristics of this chassis and shall be of type Power."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
       </EntityType>
 
       <ComplexType Name="Links" BaseType="ExampleResource.Links">
         <Annotation Term="OData.Description" String="Contains references to other resources that are related to this resource."/>
         <Annotation Term="OData.LongDescription" String="This type, as described by the Redfish Specification, shall contain references to resources that are related to, but not contained by (subordinate to), this resource."/>
-        <NavigationProperty Name="ManagedBy" Type="Collection(Manager.Manager)">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="An array of references to the Managers responsible for managing this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a reference to the resource that manages this chassis and shall reference a resource of type Manager."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
         <NavigationProperty Name="ContainedBy" Type="Example.Example" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="A reference to the chassis that this chassis is contained by."/>
@@ -495,12 +477,6 @@
           <Annotation Term="Validation.Minimum" Int="0"/>
           <Annotation Term="Measures.Unit" String="kg"/>
         </Property>
-        <NavigationProperty Name="NetworkAdapters" Type="NetworkAdapterCollection.NetworkAdapterCollection" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the collection of Network Adapters associated with this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a collection of type NetworkAdapterCollection."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
       </EntityType>
 
       <ComplexType Name="Links" BaseType="Example.v1_2_0.Links">
@@ -561,12 +537,6 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to add a link to an Assembly resource."/>
       <EntityType Name="Example" BaseType="Example.v1_5_2.Example">
-        <NavigationProperty Name="Assembly" Type="Assembly.Assembly" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the Assembly resource associated with this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a resource of type Assembly."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
       </EntityType>
     </Schema>
 

--- a/validateRedfish.py
+++ b/validateRedfish.py
@@ -439,7 +439,7 @@ def checkPropertyConformance(service, prop_name, prop, parent_name=None, parent_
         for n, sub_obj in enumerate(prop.Collection):
             try:
                 if sub_obj.Value is None:
-                    if propNullablePass:
+                    if sub_obj.Type.IsNullable:
                         counts['pass'] += 1
                         result_str = 'PASS'
                     else:

--- a/validateRedfish.py
+++ b/validateRedfish.py
@@ -106,9 +106,11 @@ def validateEntity(service, prop, val, parentURI=""):
     # check if the entity is truly what it's supposed to be
     # if not autoexpand, we must grab the resource
     if not autoExpand:
-        success, data, status, delay = service.callResourceURI(uri)
+        success, data, _, delay = service.callResourceURI(uri)
+        status = _.status
     else:
-        success, data, status, delay = True, val, 200, 0
+        success, data, _, delay = True, val, None, 0
+        status = 200
 
     generics = ['Resource.ItemOrCollection', 'Resource.ResourceCollection', 'Resource.Item', 'Resource.Resource']
     my_type = prop.Type.parent_type[0] if prop.Type.IsPropertyType else prop.Type.fulltype

--- a/validateRedfish.py
+++ b/validateRedfish.py
@@ -438,13 +438,28 @@ def checkPropertyConformance(service, prop_name, prop, parent_name=None, parent_
                         'complex')
         for n, sub_obj in enumerate(prop.Collection):
             try:
-                subMsgs, subCounts = validateComplex(service, sub_obj, prop_name, oem_check)
-                if len(prop.Collection) == 1:
-                    subMsgs = {'{}.{}'.format(prop_name,x):y for x,y in subMsgs.items()}
+                if sub_obj.Value is None:
+                    if propNullablePass:
+                        counts['pass'] += 1
+                        result_str = 'PASS'
+                    else:
+                        my_logger.error('{}: Property is null but is not Nullable'.format(prop_name))
+                        counts['failNullable'] += 1
+                        result_str = 'FAIL'
+                    if len(prop.Collection) == 1:
+                        resultList['{}.<Value>'.format(prop_name)] = ('[null]', displayType(prop.Type),
+                                                                      'Yes' if prop.Exists else 'No', result_str)
+                    else:
+                        resultList['{}.<Value>#{}'.format(prop_name,n)] = ('[null]', displayType(prop.Type),
+                                                                           'Yes' if prop.Exists else 'No', result_str)
                 else:
-                    subMsgs = {'{}.{}#{}'.format(prop_name,x,n):y for x,y in subMsgs.items()}
-                resultList.update(subMsgs)
-                counts.update(subCounts)
+                    subMsgs, subCounts = validateComplex(service, sub_obj, prop_name, oem_check)
+                    if len(prop.Collection) == 1:
+                        subMsgs = {'{}.{}'.format(prop_name,x):y for x,y in subMsgs.items()}
+                    else:
+                        subMsgs = {'{}.{}#{}'.format(prop_name,x,n):y for x,y in subMsgs.items()}
+                    resultList.update(subMsgs)
+                    counts.update(subCounts)
             except Exception as ex:
                 my_logger.log(logging.INFO-1, 'Exception caught while validating Complex', exc_info=1)
                 my_logger.error('{}: Could not finish check on this property ({})'.format(prop_name, str(ex)))

--- a/validateResource.py
+++ b/validateResource.py
@@ -142,8 +142,12 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
             if redfish_obj.HasValidUri:
                 counts['passRedfishUri'] += 1
             else:
-                counts['failRedfishUri'] += 1
-                my_logger.error('URI {} does not match the following required URIs in Schema of {}'.format(odata_id, redfish_obj.Type))
+                if '/Oem/' in odata_id:
+                    counts['warnRedfishUri'] += 1
+                    my_logger.warning('URI {} does not match the following required URIs in Schema of {}'.format(odata_id, redfish_obj.Type))
+                else:
+                    counts['failRedfishUri'] += 1
+                    my_logger.error('URI {} does not match the following required URIs in Schema of {}'.format(odata_id, redfish_obj.Type))
 
     if not successPayload:
         counts['failPayloadError'] += 1

--- a/validateResource.py
+++ b/validateResource.py
@@ -164,8 +164,8 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
             my_logger.error('Allow header should NOT contain DELETE for {}'.format(redfish_obj.Type))
             counts['failAllowHeader'] += 1
         if not redfish_obj.Type.CanUpdate and any([x in allowed_responses for x in ['PATCH', 'PUT']]):
-            my_logger.error('Allow header should NOT contain PATCH or PUT for {}'.format(redfish_obj.Type))
-            counts['failAllowHeader'] += 1
+            my_logger.warning('Allow header should NOT contain PATCH or PUT for {}'.format(redfish_obj.Type))
+            counts['warnAllowHeader'] += 1
 
     if not successPayload:
         counts['failPayloadError'] += 1


### PR DESCRIPTION
The tool can now check URIs on any service at and above version 1.6.0, testing all @odata.id possible on each Resource.

Now tests headers to check if Capabilities is properly applied to the Allow header.

Small tweaks

MinVersion is now lessthan or equal

Nav properties now have RedfishType.IsNav

Fix modified results using `success` rather than `result`

ex:
![image](https://user-images.githubusercontent.com/5571676/140568593-83793d91-a643-4120-b79e-f8a855c53ebe.png)


EDIT:

Changed Error to Warn on PATCH/PUT header

Renamed variables, made URI checking less strict

Loosened URI pattern regex, Pound sign check for fragments

Change fulltype variable, proper check for incorrect non-dictionary RedfishObject values
