### PR TITLE
Add URI checking and Capabilities checking, bug tweaks, Registry files (squashed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Variable   | Type   | Definition
 Version    | string | Internal config version (optional)
 Copyright  | string | _DMTF_ copyright (optional)
 verbose    | int    | level of verbosity (0-3) 
+
 ### [Host]
+
 Variable   | Type    | Definition
 --         |--       |--
 ip         | string  | Host of testing system, formatted as https:// ip : port (can use http as well)
@@ -56,15 +58,18 @@ authtype   | string  | Authorization type (Basic | Session | Token | None)
 token      | string  | Token string for Token authentication
 
 ### [Validator]
+
 Variable        | Type    | Definition
 --              |--       |--
 payload         | string  | Option to test a specific payload or resource tree (see below)
 logdir          | string  | Place to save logs and run configs
 oemcheck        | boolean | Whether to check Oem items on service
+uricheck        | boolean | Allow URI checking on services below RedfishVersion 1.6.0
 debugging       | boolean | Whether to print debug to log
 schema_directory| string  | Where schema is located/saved on system
 
 ### Payload options
+
 The payload option takes two parameters as "option uri"
 
 (Single, SingleFile, Tree, TreeFile)

--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -46,6 +46,7 @@ def main(argslist=None, configfile=None):
     argget.add_argument('--logdir', type=str, default='./logs', help='directory for log files')
     argget.add_argument('--nooemcheck', action='store_false', dest='oemcheck', help='Don\'t check OEM items')
     argget.add_argument('--debugging', action="store_true", help='Output debug statements to text log, otherwise it only uses INFO')
+    argget.add_argument('--uricheck', action="store_true", help='Allow URI checking on services below RedfishVersion 1.6.0')
     argget.add_argument('--schema_directory', type=str, default='./SchemaFiles/metadata', help='directory for local schema files')
 
     # parse...
@@ -120,7 +121,7 @@ def main(argslist=None, configfile=None):
 
     import common.traverse as traverse
     try:
-        currentService = traverse.startService(vars(args))
+        currentService = traverse.rfService(vars(args))
     except Exception as ex:
         my_logger.log(logging.INFO-1, 'Exception caught while creating Service', exc_info=1)
         my_logger.error("Service could not be started: {}".format(repr(ex)))

--- a/RedfishServiceValidatorGui.py
+++ b/RedfishServiceValidatorGui.py
@@ -78,6 +78,10 @@ g_config_defaults = {
             "value": "False",
             "description": "Whether to print debug to log"
         },
+        "uricheck": {
+            "value": "False",
+            "description": "Whether to force urichecking if under RedfishVersion 1.6.0"
+        },
         "schema_directory": {
             "value": "./SchemaFiles/metadata",
             "description": "Where schema is located/saved on system"

--- a/common/catalog.py
+++ b/common/catalog.py
@@ -125,6 +125,8 @@ class SchemaCatalog:
         :return: Schema Document
         :rtype: SchemaDoc
         """
+        if 'Collection(' in typename:
+            typename = typename.replace('Collection(', "").replace(')', "")
         typename = getNamespaceUnversioned(typename)
         typename = self.alias.get(typename, typename)
         if typename in self.catalog_by_class:
@@ -948,10 +950,6 @@ class RedfishObject(RedfishProperty):
                                     rsc_type, rsc_value, odata_value = rsc
                                     my_str = re.sub('\{|Id\}|', '', section)
                                     sub_obj.HasValidUriStrict = sub_obj.HasValidUriStrict and rsc_type == my_str and rsc_value == odata_value
-                                    if rsc_type != my_str:
-                                        my_logger.warning('Resource tree in URI {} has incorrect typing: {} {}'.format(my_odata_id, rsc_type, my_str))
-                                    if rsc_value != odata_value:
-                                        my_logger.warning('Resource tree in URI {} has incorrect ID: {} {}'.format(my_odata_id, rsc_value, odata_value))
 
                             if sub_obj.HasValidUriStrict:
                                 break

--- a/common/catalog.py
+++ b/common/catalog.py
@@ -8,7 +8,6 @@ from os import path
 from bs4 import BeautifulSoup
 
 from common.helper import (
-    compareMinVersion,
     getNamespace,
     getNamespaceUnversioned,
     getType,
@@ -316,7 +315,7 @@ class SchemaClass:
             if limit is not None:
                 if getVersion(newNamespace) is None:
                     continue
-                if compareMinVersion(newNamespace, limit):
+                if splitVersionString(newNamespace) > splitVersionString(limit):
                     continue
             if (my_type in self.my_types):
                 typelist.append(splitVersionString(newNamespace))
@@ -896,7 +895,7 @@ class RedfishObject(RedfishProperty):
                     # get type order from bottom up of schema, check if my_type in that schema
                     for top_ns, schema in reversed(list(sub_obj.Type.catalog.getSchemaDocByClass(my_ns).classes.items())):
                         if my_type in schema.my_types:
-                            if compareMinVersion(top_ns, my_limit):
+                            if splitVersionString(top_ns) <= splitVersionString(my_limit):
                                 my_ns = top_ns
                                 break
                     # ISSUE: We can't cast under v1_0_0, get the next best Type

--- a/common/catalog.py
+++ b/common/catalog.py
@@ -833,6 +833,7 @@ class RedfishObject(RedfishProperty):
                 sub_obj.HasValidUri = True
                 sub_obj.HasValidUriStrict = False
                 sub_obj.properties = {x:y.populate(REDFISH_ABSENT) for x, y in sub_obj.properties.items()}
+                evals.append(sub_obj)
                 continue
 
             # Cast types if they're below their parent or are OemObjects

--- a/common/config.py
+++ b/common/config.py
@@ -11,7 +11,7 @@ my_logger.setLevel(logging.DEBUG)
 config_struct = {
     'Tool': ['verbose'],
     'Host': ['ip', 'username', 'password', 'description', 'forceauth', 'authtype', 'token'],
-    'Validator': ['payload', 'logdir', 'oemcheck', 'debugging', 'schema_directory']
+    'Validator': ['payload', 'logdir', 'oemcheck', 'debugging', 'schema_directory', 'uricheck']
 }
 
 config_options = [x for name in config_struct for x in config_struct[name]]

--- a/common/helper.py
+++ b/common/helper.py
@@ -27,33 +27,24 @@ def create_entry(name, value, type, exists, result):
     })
 
 
-def splitVersionString(version):
-    v_payload = version
-    if(re.match('([a-zA-Z0-9_.-]*\.)+[a-zA-Z0-9_.-]*', version) is not None):
-        new_payload = getVersion(version)
-        if new_payload is not None:
-            v_payload = new_payload
-    if ('_' in v_payload):
-        v_payload = v_payload.replace('v', '')
-        payload_split = v_payload.split('_')
+def splitVersionString(v_string):
+    """
+    Split x.y.z and Namespace.vX_Y_Z, vX_Y_Z type version strings into tuples of integers
+
+    :return: tuple of integers
+    """
+    if(re.match('([a-zA-Z0-9_.-]*\.)+[a-zA-Z0-9_.-]*', v_string) is not None):
+        new_string = getVersion(v_string)
+        if new_string is not None:
+            v_string = new_string
+    if ('_' in v_string):
+        v_string = v_string.replace('v', '')
+        payload_split = v_string.split('_')
     else:
-        payload_split = v_payload.split('.')
+        payload_split = v_string.split('.')
     if len(payload_split) != 3:
         return tuple([0, 0, 0])
     return tuple([int(v) for v in payload_split])
-
-
-def compareMinVersion(version, min_version):
-    """
-    Checks for the minimum version of a resource's type
-    """
-    # If version doesn't contain version as is, try it as v#_#_#
-    # get version from payload
-    min_split = splitVersionString(min_version)
-    payload_split = splitVersionString(version)
-
-    # use array comparison, which compares each sequential number
-    return min_split <= payload_split
 
 
 def navigateJsonFragment(decoded, URILink):

--- a/common/helper.py
+++ b/common/helper.py
@@ -39,8 +39,8 @@ def splitVersionString(version):
     else:
         payload_split = v_payload.split('.')
     if len(payload_split) != 3:
-        return [0, 0, 0]
-    return [int(v) for v in payload_split]
+        return tuple([0, 0, 0])
+    return tuple([int(v) for v in payload_split])
 
 
 def compareMinVersion(version, min_version):
@@ -53,7 +53,7 @@ def compareMinVersion(version, min_version):
     payload_split = splitVersionString(version)
 
     # use array comparison, which compares each sequential number
-    return min_split < payload_split
+    return min_split <= payload_split
 
 
 def navigateJsonFragment(decoded, URILink):

--- a/common/schema.py
+++ b/common/schema.py
@@ -75,7 +75,7 @@ def getSchemaDetails(service, SchemaType, SchemaURI):
             base_schema_uri, frag = tuple(SchemaURI.rsplit('#', 1))
         else:
             base_schema_uri, frag = SchemaURI, None
-        success, data, status, elapsed = service.callResourceURI(base_schema_uri)
+        success, data, response, elapsed = service.callResourceURI(base_schema_uri)
         if success:
             soup = BeautifulSoup(data, "xml")
             # if frag, look inside xml for real target as a reference

--- a/common/schema.py
+++ b/common/schema.py
@@ -3,11 +3,12 @@
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Service-Validator/blob/master/LICENSE.md
 
 from collections import namedtuple
+from re import split
 from bs4 import BeautifulSoup
 from functools import lru_cache
 import os.path
 
-from common.helper import getType, getNamespace, getNamespaceUnversioned, getVersion, compareMinVersion, splitVersionString
+from common.helper import getType, getNamespace, getNamespaceUnversioned, getVersion, splitVersionString
 
 import logging
 my_logger = logging.getLogger(__name__)
@@ -313,7 +314,7 @@ class rfSchema:
             if limit is not None:
                 if getVersion(newNamespace) is None:
                     continue
-                if compareMinVersion(newNamespace, limit):
+                if splitVersionString(newNamespace) > splitVersionString(limit):
                     continue
             if schema.find(['EntityType', 'ComplexType'], attrs={'Name': getType(acquiredtype)}, recursive=False):
                 typelist.append(splitVersionString(newNamespace))

--- a/common/traverse.py
+++ b/common/traverse.py
@@ -10,7 +10,7 @@ from http.client import responses
 
 import redfish as rf
 import common.catalog as catalog
-from common.helper import navigateJsonFragment, compareMinVersion
+from common.helper import navigateJsonFragment, splitVersionString
 from common.metadata import Metadata
 
 import logging
@@ -68,7 +68,7 @@ class rfService():
                 target_version = data['RedfishVersion']
         if target_version in ['1.0.0', 'n/a']:
             traverseLogger.warning('!!Version of target may produce issues!!')
-        if not compareMinVersion(target_version, '1.6.0') and not self.config['uricheck']:
+        if splitVersionString(target_version) < splitVersionString('1.6.0') and not self.config['uricheck']:
             traverseLogger.warning('RedfishVersion below 1.6.0, disabling uri checks')
             self.catalog.flags['ignore_uri_checks'] = True
         else:

--- a/common/traverse.py
+++ b/common/traverse.py
@@ -10,7 +10,7 @@ from http.client import responses
 
 import redfish as rf
 import common.catalog as catalog
-from common.helper import navigateJsonFragment
+from common.helper import navigateJsonFragment, compareMinVersion
 from common.metadata import Metadata
 
 import logging
@@ -28,19 +28,6 @@ def getLogger():
     Grab logger for tools that might use this lib
     """
     return my_logger
-
-def startService(config):
-    """startService
-
-    Begin service to use, sets as global
-
-    Notes: Strip globals, turn into normal factory
-
-    :param config: configuration of service
-    :param defaulted: config options not specified by the user
-    """
-    newService = rfService(config)
-    return newService
 
 class rfService():
     def __init__(self, config):
@@ -70,7 +57,7 @@ class rfService():
         target_version = 'n/a'
 
         # get Version
-        success, data, status, delay = self.callResourceURI('/redfish/v1')
+        success, data, response, delay = self.callResourceURI('/redfish/v1')
         if not success:
             traverseLogger.warn('Could not get ServiceRoot')
         else:
@@ -81,11 +68,17 @@ class rfService():
                 target_version = data['RedfishVersion']
         if target_version in ['1.0.0', 'n/a']:
             traverseLogger.warning('!!Version of target may produce issues!!')
+        if not compareMinVersion(target_version, '1.6.0') and not self.config['uricheck']:
+            traverseLogger.warning('RedfishVersion below 1.6.0, disabling uri checks')
+            self.catalog.flags['ignore_uri_checks'] = True
+        else:
+            self.catalog.flags['ignore_uri_checks'] = False
+            self.config['uricheck'] = True
         
         self.service_root = data
-        success, data, status, delay = self.callResourceURI(Metadata.metadata_uri)
+        success, data, response, delay = self.callResourceURI(Metadata.metadata_uri)
 
-        if success and data is not None and status in range(200,210):
+        if success and data is not None and response.status in range(200,210):
             self.metadata = Metadata(data, self, my_logger)
         else:
             self.metadata = Metadata(None, self, my_logger)
@@ -108,9 +101,10 @@ class rfService():
         # rs-assertions: 6.4.1, including accept, content-type and odata-versions
         # rs-assertion: handle redirects?  and target permissions
         # rs-assertion: require no auth for serviceroot calls
+        # TODO: Written with "success" values, should replace with Exception and catches
         if URILink is None:
             traverseLogger.warn("This URI is empty!")
-            return False, None, -1, 0
+            return False, None, None, 0
 
         config = self.config
         # proxies = self.proxies
@@ -154,8 +148,6 @@ class rfService():
             'out of service ' if not inService else '', AuthType, UseSSL, URILink, headers))
         response = None
         try:
-            if payload is not None: # and CacheMode == 'Prefer':
-                return True, payload, -1, 0
             startTick = datetime.now()
             response = self.context.get(URLDest)  # only proxy non-service
             elapsed = datetime.now() - startTick
@@ -199,7 +191,7 @@ class rfService():
                         except ValueError:
                             pass
 
-                return decoded is not None, decoded, statusCode, elapsed
+                return decoded is not None, decoded, response, elapsed
             elif statusCode == 401:
                 if inService and AuthType in ['Basic', 'Token']:
                     if AuthType == 'Token':
@@ -209,18 +201,6 @@ class rfService():
                     raise AuthenticationError('Error accessing URI {}. Status code "{} {}". Check {} supplied for "{}" authentication.'
                                               .format(URILink, statusCode, responses[statusCode], cred_type, AuthType))
 
-        # except requests.exceptions.SSLError as e:
-        #     traverseLogger.error("SSLError on {}: {}".format(URILink, repr(e)))
-        #     traverseLogger.debug("output: ", exc_info=True)
-        # except requests.exceptions.ConnectionError as e:
-        #     traverseLogger.error("ConnectionError on {}: {}".format(URILink, repr(e)))
-        #     traverseLogger.debug("output: ", exc_info=True)
-        # except requests.exceptions.Timeout as e:
-        #     traverseLogger.error("Request has timed out ({}s) on resource {}".format(timeout, URILink))
-        #     traverseLogger.debug("output: ", exc_info=True)
-        # except requests.exceptions.RequestException as e:
-        #     traverseLogger.error("Request has encounted a problem when getting resource {}: {}".format(URILink, repr(e)))
-        #     traverseLogger.debug("output: ", exc_info=True)
         except AuthenticationError as e:
             raise e  # re-raise exception
         except Exception as e:
@@ -230,5 +210,5 @@ class rfService():
                 traverseLogger.debug("payload: {}".format(response.text))
 
         if payload is not None:
-            return True, payload, -1, 0
-        return False, None, statusCode, elapsed
+            return True, payload, response, 0
+        return False, None, response, elapsed

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -24,6 +24,7 @@ class TestCatalog(unittest.TestCase):
         self.assertEqual(val, 'PropertyA')
         val = catalog.get_fuzzy_property('PropertyA', {'Name': 'Payload'}, ['PropertyB'])
         self.assertEqual(val, 'PropertyA')
+        # OK
 
     def test_catalog(self):
         print('\n')
@@ -38,6 +39,7 @@ class TestCatalog(unittest.TestCase):
         my_type = my_catalog.getTypeInCatalog('Example.v1_7_0.Example')
 
         my_type = my_catalog.getTypeInCatalog('Example.v1_2_0.Links')
+        # OK
     
     def test_schema_doc(self):
         print('\n')
@@ -66,7 +68,7 @@ class TestCatalog(unittest.TestCase):
         my_schema = my_catalog.getSchemaInCatalog('Example.v1_0_0')
     
     def test_basic_properties(self):
-        print('\n')
+        print('\nTesting basic types as json')
         prop = catalog.RedfishProperty("Edm.Int").populate(1)
         print(prop.as_json())
         prop = catalog.RedfishProperty("Edm.Decimal").populate(1.1)
@@ -77,19 +79,19 @@ class TestCatalog(unittest.TestCase):
         print(prop.as_json())
 
     def test_basic_properties_check(self):
-        print('\n')
+        print('\nTesting check values')
         prop = catalog.RedfishProperty("Edm.Int").populate(1, check=True)
         prop = catalog.RedfishProperty("Edm.Int").populate(1.1, check=True)
         prop = catalog.RedfishProperty("Edm.Int").populate("1", check=True)
         prop = catalog.RedfishProperty("Edm.Decimal").populate(1.1, check=True)
         prop = catalog.RedfishProperty("Edm.Decimal").populate("1.1", check=True)
-        prop = catalog.RedfishProperty("Edm.String").populate("1")
-        prop = catalog.RedfishProperty("Edm.String").populate(1)
+        prop = catalog.RedfishProperty("Edm.String").populate("1", check=True)
+        prop = catalog.RedfishProperty("Edm.String").populate(1, check=True)
         prop = catalog.RedfishProperty("Edm.Guid").populate("123", check=True)
         prop = catalog.RedfishProperty("Edm.Guid").populate(catalog.REDFISH_ABSENT, check=True)
     
     def test_object(self):
-        print('\n')
+        print('\nTesting object values')
         my_catalog = catalog.SchemaCatalog('./tests/testdata/schemas/')
         my_schema_doc = my_catalog.getSchemaDocByClass("ExampleResource.v1_0_0.ExampleResource")
         my_type = my_schema_doc.getTypeInSchemaDoc("ExampleResource.v1_0_0.ExampleResource")
@@ -101,6 +103,49 @@ class TestCatalog(unittest.TestCase):
         pprint.pprint(object.as_json(), indent=2)
         dct = object.as_json()
         dct = object.getLinks()
+
+    def test_capabilities(self):
+        my_catalog = catalog.SchemaCatalog('./tests/testdata/schemas/')
+        my_schema_doc = my_catalog.getSchemaDocByClass("Example.v1_0_0.Example")
+        my_type = my_schema_doc.getTypeInSchemaDoc("Example.v1_0_0.Example")
+        print(my_type.getCapabilities())
+        print(my_type.CanUpdate)
+        print(my_type.CanInsert)
+        print(my_type.CanDelete)
+    
+    def test_expected_uris(self):
+        print('\nTesting expected Uris')
+        my_catalog = catalog.SchemaCatalog('./tests/testdata/schemas/')
+        my_schema_doc = my_catalog.getSchemaDocByClass("Example.v1_0_0.Example")
+        my_type = my_schema_doc.getTypeInSchemaDoc("Example.v1_0_0.Example")
+        object = catalog.RedfishObject( my_type )
+        arr = object.Type.getUris()
+        self.assertEqual(len(arr), 2)
+        object = catalog.RedfishObject( my_type ).populate({
+            "@odata.id": "/redfish/v1/Example",
+            "Id": None,
+            "Description": None
+            })
+        print(object.HasValidUri)
+        object = catalog.RedfishObject( my_type ).populate({
+            "@odata.id": "/redfish/v1/Examples",
+            "Id": None,
+            "Description": None
+            })
+        print(object.HasValidUri)
+        object = catalog.RedfishObject( my_type ).populate({
+            "@odata.id": "/redfish/v1/Examples/FunnyId",
+            "Id": 'FunnyId',
+            "Description": None
+            })
+        print(object.HasValidUri)
+        object = catalog.RedfishObject( my_type ).populate({
+            "@odata.id": "/redfish/v1/Examples/NoId",
+            "Id": None,
+            "Description": None
+            })
+        print(object.HasValidUri)
+
 
 
 if __name__ == '__main__':

--- a/tests/testdata/schemas/Example_v1.xml
+++ b/tests/testdata/schemas/Example_v1.xml
@@ -46,6 +46,12 @@
             <PropertyValue Property="Deletable" Bool="false"/>
           </Record>
         </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Example</String>
+            <String>/redfish/v1/Examples/{ExampleId}</String>
+          </Collection>
+        </Annotation>
       </EntityType>
 
       <Action Name="ExampleAction" IsBound="true">
@@ -100,7 +106,7 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.Required"/>
         </Property>
-        <Property Name="Status" Type="ExampleExampleResource.Status" Nullable="false"/>
+        <Property Name="Status" Type="ExampleResource.Status" Nullable="false"/>
         <Property Name="cString" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
         </Property>
@@ -133,7 +139,7 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.Required"/>
         </Property>
-        <Property Name="Status" Type="ExampleExampleResource.Status" Nullable="false"/>
+        <Property Name="Status" Type="ExampleResource.Status" Nullable="false"/>
         <Property Name="pString" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
         </Property>
@@ -177,35 +183,11 @@
         <Property Name="ComplexInner" Type="Example.v1_0_0.ComplexInner" Nullable="false">
         </Property>
 
-        <NavigationProperty Name="LogServices" Type="LogServiceCollection.LogServiceCollection" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the logs for this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a collection of type LogServiceCollection."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Thermal" Type="Thermal.Thermal" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the thermal properties (fans, cooling, sensors) of this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a reference to the resource that represents the thermal characteristics of this chassis and shall be of type Thermal."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Power" Type="Power.Power" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the power properties (power supplies, power policies, sensors) of this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a reference to the resource that represents the power characteristics of this chassis and shall be of type Power."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
       </EntityType>
 
       <ComplexType Name="Links" BaseType="ExampleResource.Links">
         <Annotation Term="OData.Description" String="Contains references to other resources that are related to this resource."/>
         <Annotation Term="OData.LongDescription" String="This type, as described by the Redfish Specification, shall contain references to resources that are related to, but not contained by (subordinate to), this resource."/>
-        <NavigationProperty Name="ManagedBy" Type="Collection(Manager.Manager)">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="An array of references to the Managers responsible for managing this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a reference to the resource that manages this chassis and shall reference a resource of type Manager."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
         <NavigationProperty Name="ContainedBy" Type="Example.Example" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="A reference to the chassis that this chassis is contained by."/>
@@ -495,12 +477,6 @@
           <Annotation Term="Validation.Minimum" Int="0"/>
           <Annotation Term="Measures.Unit" String="kg"/>
         </Property>
-        <NavigationProperty Name="NetworkAdapters" Type="NetworkAdapterCollection.NetworkAdapterCollection" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the collection of Network Adapters associated with this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a collection of type NetworkAdapterCollection."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
       </EntityType>
 
       <ComplexType Name="Links" BaseType="Example.v1_2_0.Links">
@@ -561,12 +537,6 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to add a link to an Assembly resource."/>
       <EntityType Name="Example" BaseType="Example.v1_5_2.Example">
-        <NavigationProperty Name="Assembly" Type="Assembly.Assembly" ContainsTarget="true" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="A reference to the Assembly resource associated with this chassis."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a resource of type Assembly."/>
-          <Annotation Term="OData.AutoExpandReferences"/>
-        </NavigationProperty>
       </EntityType>
     </Schema>
 

--- a/validateRedfish.py
+++ b/validateRedfish.py
@@ -493,12 +493,13 @@ def checkPropertyConformance(service, prop_name, prop, parent_name=None, parent_
                 else:
                     propNullablePass = False
             
+            prop = prop.populate(val, check=True)
+
             paramPass = prop.IsValid
-        
-            paramPass = prop.populate(val, True)
 
             if propRealType == 'entity':
                 paramPass = validateEntity(service, prop, val)
+            
 
 
         # Render our result

--- a/validateRedfish.py
+++ b/validateRedfish.py
@@ -106,12 +106,14 @@ def validateEntity(service, prop, val, parentURI=""):
     # check if the entity is truly what it's supposed to be
     # if not autoexpand, we must grab the resource
     if not autoExpand:
-        success, data, status, delay = service.callResourceURI(uri)
+        success, data, _, delay = service.callResourceURI(uri)
+        status = _.status
     else:
-        success, data, status, delay = True, val, 200, 0
+        success, data, _, delay = True, val, None, 0
+        status = 200
 
     generics = ['Resource.ItemOrCollection', 'Resource.ResourceCollection', 'Resource.Item', 'Resource.Resource']
-    my_type = prop.Type.parent_type[0] if prop.Type.IsPropertyType else prop.Type.fulltype
+    my_type = prop.Type.fulltype
     if success and my_type in generics:
         return True
     elif success:
@@ -124,6 +126,7 @@ def validateEntity(service, prop, val, parentURI=""):
             my_target_schema = prop.Type.catalog.getSchemaDocByClass(getNamespaceUnversioned(my_target_type))
         except MissingSchemaError:
             my_logger.error("{}: Could not get schema file for Entity check".format(name))
+            return False
 
         if getNamespace(my_target_type) not in my_target_schema.classes:
             my_logger.error('{}: Linked resource reports version {} not in Schema'.format(name.split(':')[-1], my_target_type))
@@ -238,7 +241,7 @@ def displayType(propTypeObject, is_collection=False):
     :return: the simplified type to display
     """
     propRealType, propCollection = propTypeObject.getBaseType()
-    propType = propTypeObject.parent_type[0] if propTypeObject.IsPropertyType else propTypeObject.fulltype
+    propType = propTypeObject.fulltype
     # Edm.* and other explicit types
     if propRealType == 'Edm.Boolean' or propRealType == 'Boolean':
         disp_type = 'boolean'
@@ -496,7 +499,7 @@ def checkPropertyConformance(service, prop_name, prop, parent_name=None, parent_
 
 
         # Render our result
-        my_type = prop.Type.parent_type[0] if prop.Type.IsPropertyType else prop.Type.fulltype
+        my_type = prop.Type.fulltype
 
         if all([paramPass, propMandatoryPass, propNullablePass, excerptPass]):
             my_logger.log(logging.INFO-1,"\tSuccess")

--- a/validateRedfish.py
+++ b/validateRedfish.py
@@ -94,6 +94,9 @@ def validateEntity(service, prop, val, parentURI=""):
     my_logger.debug('validateEntity: name = {}'.format(name))
 
     # check for required @odata.id
+    if not isinstance(val, dict):
+        my_logger.info("{}: EntityType val is null/absent, not testing...".format(name))
+        return False
     uri = val.get('@odata.id')
     if '@odata.id' not in val:
         if autoExpand: uri = parentURI + '#/{}'.format(name.replace('[', '/').strip(']'))

--- a/validateResource.py
+++ b/validateResource.py
@@ -296,6 +296,9 @@ def validateURITree(service, URI, uriName, expectedType=None, expectedJson=None,
         log_entries = [x for x in links if 'LogEntry' in x.Type.fulltype]
         links = [x for x in links if 'LogEntry' not in x.Type.fulltype] + log_entries[:15] # Pare down logentries
         for link in sorted(links, key=lambda x: (x.Type.fulltype != 'Registries.Registries')):
+            if link.Value is None:
+                my_logger.warning('Link of name link.Name returning a None, does it exist?')
+                continue
             link_destination = link.Value.get('@odata.id')
             if link.Type.Excerpt:
                 continue

--- a/validateResource.py
+++ b/validateResource.py
@@ -74,9 +74,11 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
     try:
         if expectedJson is None:
             ret = service.callResourceURI(URI)
-            success, me['payload'], me['rcode'], me['rtime'] = ret
+            success, me['payload'], response, me['rtime'] = ret
+            me['rcode'] = response.status
         else:
             success, me['payload'], me['rcode'], me['rtime'] = True, expectedJson, -1, 0
+            response = None
         
         if not success:
             my_logger.error('URI did not return resource {}'.format(URI))
@@ -96,14 +98,16 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
         if my_type is None:
             redfish_obj = None
         else:
+            # TODO: don't have the distinction between Property Type and a Normal Type
             if isinstance(my_type, catalog.RedfishType):
-                my_type = my_type.parent_type[0] if my_type.IsPropertyType else my_type.fulltype
+                my_type = my_type.fulltype
             redfish_schema = service.catalog.getSchemaDocByClass(my_type)
             redfish_type = redfish_schema.getTypeInSchemaDoc(my_type)
             redfish_obj = catalog.RedfishObject(redfish_type, 'Object', parent=parent).populate(me['payload']) if redfish_type else None
-            me['fulltype'] = redfish_obj.Type.fulltype
 
-        if not redfish_obj:
+        if redfish_obj:
+            me['fulltype'] = redfish_obj.Type.fulltype
+        else:
             counts['problemResource'] += 1
             me['warns'], me['errors'] = get_my_capture(my_logger, whandler), get_my_capture(my_logger, ehandler)
             return False, counts, results, None, None
@@ -119,8 +123,8 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
     counts['passGet'] += 1
 
     # verify odata_id properly resolves to its parent if holding fragment
-    odata_id = me['payload'].get('@odata.id', '')
-    if '#' in odata_id:
+    odata_id = me['payload'].get('@odata.id')
+    if odata_id is not None and '#' in odata_id:
         if parent is not None:
             payload_resolve = navigateJsonFragment(parent.payload, URI)
             if parent.payload.get('@odata.id') not in URI:
@@ -133,6 +137,35 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
                 counts['badOdataIdResolution'] += 1
         else:
             my_logger.warn('No parent found with which to test @odata.id of ReferenceableMember')
+    
+    if service.config['uricheck']:
+        my_uris = redfish_obj.Type.getUris()
+        if odata_id is not None and redfish_obj.Populated and len(my_uris) > 0:
+            if redfish_obj.HasValidUri:
+                counts['passRedfishUri'] += 1
+            else:
+                if '/Oem/' in odata_id:
+                    counts['warnRedfishUri'] += 1
+                    modified_entry = messages['@odata.id']
+                    modified_entry.result = 'WARN'
+                    my_logger.warning('URI {} does not match the following required URIs in Schema of {}'.format(odata_id, redfish_obj.Type))
+                else:
+                    counts['failRedfishUri'] += 1
+                    modified_entry = messages['@odata.id']
+                    modified_entry.result = 'FAIL'
+                    my_logger.error('URI {} does not match the following required URIs in Schema of {}'.format(odata_id, redfish_obj.Type))
+
+    if response and response.getheader('Allow'):
+        allowed_responses = [x.strip().upper() for x in response.getheader('Allow').split(',')]
+        if not redfish_obj.Type.CanInsert and 'POST' in allowed_responses:
+            my_logger.error('Allow header should NOT contain POST for {}'.format(redfish_obj.Type))
+            counts['failAllowHeader'] += 1
+        if not redfish_obj.Type.CanDelete and 'DELETE' in allowed_responses:
+            my_logger.error('Allow header should NOT contain DELETE for {}'.format(redfish_obj.Type))
+            counts['failAllowHeader'] += 1
+        if not redfish_obj.Type.CanUpdate and any([x in allowed_responses for x in ['PATCH', 'PUT']]):
+            my_logger.warning('Allow header should NOT contain PATCH or PUT for {}'.format(redfish_obj.Type))
+            counts['warnAllowHeader'] += 1
 
     if not successPayload:
         counts['failPayloadError'] += 1
@@ -161,7 +194,7 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
 
             if '@Redfish.Copyright' in propMessages:
                 modified_entry = propMessages['@Redfish.Copyright']
-                modified_entry.success = 'FAIL'
+                modified_entry.result = 'FAIL'
                 my_logger.error('@Redfish.Copyright is only allowed for mockups, and should not be allowed in official implementations')
 
             messages.update(propMessages)
@@ -325,8 +358,8 @@ def validateURITree(service, URI, uriName, expectedType=None, expectedJson=None,
                 continue
 
 
-            my_link_type = link.Type.parent_type[0] if link.Type.IsPropertyType else link.Type.fulltype
-            success, my_data, _, __ = service.callResourceURI(link_destination)
+            my_link_type = link.Type.fulltype
+            success, my_data, _, _ = service.callResourceURI(link_destination)
             # Using None instead of refparent simply because the parent is not where the link comes from
             returnVal = validateURITree(service, link_destination, uriName + ' -> ' + link.Name,
                     my_link_type, my_data, None, allLinks)


### PR DESCRIPTION
The tool can now check URIs on any service at and above version 1.6.0,
testing all @odata.id possible on each Resource.

Now tests headers to check if Capabilities is properly applied to the
Allow header.

fix: MinVersion is now lessthan or equal

fix: Fix modified results using success rather than result

tweak: Changes to support checking headers...

...

Changed Error to Warn on PATCH/PUT header msg

Renamed variables several variables, made URI checking less strict

Loosened URI pattern regex, Pound sign check for fragments

...

tweak/fix: Simplified fulltype variable, proper check for incorrect non-dictionary RedfishObject values

fix: Fixed DynamicProperties being incorrectly pulled from schema

