### PR TITLE
Fix output for lists of 'ComplexType'

### DIFF
--- a/validateRedfish.py
+++ b/validateRedfish.py
@@ -458,7 +458,9 @@ def checkPropertyConformance(service, prop_name, prop, parent_name=None, parent_
                                                                            'Yes' if prop.Exists else 'No', result_str)
                 else:
                     subMsgs, subCounts = validateComplex(service, sub_obj, prop_name, oem_check)
-                    if len(prop.Collection) == 1:
+                    if isCollection:
+                        subMsgs = {'{}[{}].{}'.format(prop_name,n,x):y for x,y in subMsgs.items()}
+                    elif len(prop.Collection) == 1:
                         subMsgs = {'{}.{}'.format(prop_name,x):y for x,y in subMsgs.items()}
                     else:
                         subMsgs = {'{}.{}#{}'.format(prop_name,x,n):y for x,y in subMsgs.items()}


### PR DESCRIPTION
   E.g. for EthernetInterface.v1_6_4.EthernetInterface IPv4Addresses lists,
   the list index "[<index>]" was missing in HTML/CSV output. For lists of
   size 1 the index was missing completely, otherwise "#<index>" was appended,
   e.g. "IPv4Addresses.SubnetMask#1".

   With this change, regardless of the size of the list, "[<index>]" will be
   used in the same way as for "Members" etc, e.g.
   "IPv4Addresses[1].SubnetMask".

Signed-off-by: Andreas Heynig <andreas.heynig@mk-logic.de>