### PR TITLE
Corrected scanning of object properties within OEM objects

### DIFF
--- a/common/catalog.py
+++ b/common/catalog.py
@@ -962,9 +962,9 @@ class RedfishObject(RedfishProperty):
                                 break
 
             # TODO: Oem support is able, but it is tempermental for Actions and Additional properties
-            if 'Resource.OemObject' in sub_obj.Type.getTypeTree():
-                evals.append(sub_obj)
-                continue
+            #if 'Resource.OemObject' in sub_obj.Type.getTypeTree():
+            #    evals.append(sub_obj)
+            #    continue
 
             # populate properties
             if sub_obj.Name == 'Actions':

--- a/common/config.py
+++ b/common/config.py
@@ -27,7 +27,7 @@ def convert_args_to_config(args):
                 if isinstance(my_var, list):
                     my_var = ' '.join(my_var)
                     print(my_var)
-                my_config.set(section, option, str(my_var) if my_var else '')
+                my_config.set(section, option, str(my_var) if my_var is not None else '')
             else:
                 my_config.set(section, option, '******')
     return my_config


### PR DESCRIPTION
Fix #444 

Partially addresses some of the `--nooemcheck` usage for setting up the configuration file. More work needed in this for skipping links found inside `Oem`.