### PR TITLE
Specify that any content encoding is allowed

### DIFF
--- a/common/traverse.py
+++ b/common/traverse.py
@@ -139,7 +139,7 @@ class rfService():
             auth = None
 
         # only send token when we're required to chkauth, during a Session, and on Service and Secure
-        headers = {}
+        headers = {"Accept-Encoding": "*"}
 
         certVal = ChkCertBundle if ChkCert and ChkCertBundle not in [None, ""] else ChkCert
 
@@ -149,7 +149,7 @@ class rfService():
         response = None
         try:
             startTick = datetime.now()
-            response = self.context.get(URLDest)  # only proxy non-service
+            response = self.context.get(URLDest, headers=headers)
             elapsed = datetime.now() - startTick
             statusCode = response.status
 


### PR DESCRIPTION
Fix #452 

From testing, this change is not needed if the python-redfish-library is version 3.1.0 or higher, but this has no negative consequences if the latest is used.