### PR TITLE
Added check to ensure a reference object is an object prior to attempting to extract the link information

### DIFF
--- a/validateResource.py
+++ b/validateResource.py
@@ -301,6 +301,12 @@ def validateURITree(service, URI, uriName, expectedType=None, expectedJson=None,
                 continue
 
             # get Uri or @odata.id
+            if not isinstance(link.Value, dict):
+                errmsg = '{} is expected to be an object containing @odata.id'.format(link.Name)
+                my_logger.error(errmsg)
+                results[uriName]['errors'] += '\n' + errmsg
+                counts['errorInvalidReferenceObject'] += 1
+                continue
             link_destination = link.Value.get('@odata.id', link.Value.get('Uri'))
 
             if link.Type.Excerpt:


### PR DESCRIPTION
Fix #458 