### PR TITLE
Unify to use logger.warning

### DIFF
--- a/common/catalog.py
+++ b/common/catalog.py
@@ -476,7 +476,7 @@ class RedfishType:
 
             except Exception as e:
                 my_logger.debug('Exception caught while checking Dynamic', exc_info=1)
-                my_logger.warn('Could not gather info from DynamicProperties annotation')
+                my_logger.warning('Could not gather info from DynamicProperties annotation')
                 return None 
         
         return None
@@ -500,7 +500,7 @@ class RedfishType:
                     expectedUris += [e.contents[0] for e in all_strings]
                 except Exception as e:
                     my_logger.debug('Exception caught while checking Uri', exc_info=1)
-                    my_logger.warn('Could not gather info from Redfish.Uris annotation')
+                    my_logger.warning('Could not gather info from Redfish.Uris annotation')
                     expectedUris = []
         return expectedUris
      
@@ -932,7 +932,7 @@ class RedfishObject(RedfishProperty):
                         my_logger.warning('Found uri with fragment, which Resource.Resource types do not use {}'.format(my_odata_id))
                 elif 'Resource.ReferenceableMember' in sub_obj.Type.getTypeTree():
                     if '#' not in my_odata_id:
-                        my_logger.warn('No fragment in URI, but ReferenceableMembers require it {}'.format(my_odata_id))
+                        my_logger.warning('No fragment in URI, but ReferenceableMembers require it {}'.format(my_odata_id))
 
                 # iterate through our resource chain, if possible, to check IDs matching
                 # this won't check NavigationProperties but the Resources will
@@ -1073,4 +1073,3 @@ class RedfishObject(RedfishProperty):
                             item.InAnnotation = True
                         links.extend(my_links)
         return links
-

--- a/common/helper.py
+++ b/common/helper.py
@@ -154,7 +154,7 @@ def checkPayloadConformance(jsondata, uri):
                 my_logger.error("{} {}: Expected format is /path/to/uri, but received: {}".format(uri, key, decoded[key]))
             else:
                 if uri != '' and decoded[key] != uri:
-                    my_logger.warn("{} {}: Expected @odata.id to match URI link {}".format(uri, key, decoded[key]))
+                    my_logger.warning("{} {}: Expected @odata.id to match URI link {}".format(uri, key, decoded[key]))
         elif key == '@odata.count':
             paramPass = isinstance(decoded[key], int)
             if not paramPass:
@@ -164,7 +164,7 @@ def checkPayloadConformance(jsondata, uri):
             paramPass = re.match(
                 '/redfish/v1/\$metadata#([a-zA-Z0-9_.-]*\.)[a-zA-Z0-9_.-]*', decoded[key]) is not None
             if not paramPass:
-                my_logger.warn("{} {}: Expected format is /redfish/v1/$metadata#ResourceType, but received: {}".format(uri, key, decoded[key]))
+                my_logger.warning("{} {}: Expected format is /redfish/v1/$metadata#ResourceType, but received: {}".format(uri, key, decoded[key]))
                 info.append((key, decoded[key], 'odata', 'Exists', 'WARN'))
                 continue
         elif key == '@odata.type':

--- a/common/schema.py
+++ b/common/schema.py
@@ -150,7 +150,7 @@ def getSchemaDetailsLocal(SchemaType, SchemaURI, config):
             my_logger.debug("Unable to find a xml of {} at {}, defaulting to {}".format(SchemaURI, SchemaLocation, Alias + SchemaSuffix))
             return getSchemaDetailsLocal(SchemaType, Alias + SchemaSuffix, config)
         else:
-            my_logger.warn("Schema file {} not found in {}".format(filestring, SchemaLocation))
+            my_logger.warning("Schema file {} not found in {}".format(filestring, SchemaLocation))
             if Alias == '$metadata':
                 my_logger.warning("If $metadata cannot be found, Annotations may be unverifiable")
     except Exception as ex:
@@ -341,4 +341,3 @@ def getSchemaObject(service, typename, uri, metadata=None):
     success, soup, origin = getSchemaDetails(service, typename, uri)
 
     return rfSchema(soup, uri, origin, metadata=metadata, name=typename) if success else None
-

--- a/common/traverse.py
+++ b/common/traverse.py
@@ -59,10 +59,10 @@ class rfService():
         # get Version
         success, data, response, delay = self.callResourceURI('/redfish/v1')
         if not success:
-            traverseLogger.warn('Could not get ServiceRoot')
+            traverseLogger.warning('Could not get ServiceRoot')
         else:
             if 'RedfishVersion' not in data:
-                traverseLogger.warn('Could not get RedfishVersion from ServiceRoot')
+                traverseLogger.warning('Could not get RedfishVersion from ServiceRoot')
             else:
                 traverseLogger.info('Redfish Version of Service: {}'.format(data['RedfishVersion']))
                 target_version = data['RedfishVersion']
@@ -103,7 +103,7 @@ class rfService():
         # rs-assertion: require no auth for serviceroot calls
         # TODO: Written with "success" values, should replace with Exception and catches
         if URILink is None:
-            traverseLogger.warn("This URI is empty!")
+            traverseLogger.warning("This URI is empty!")
             return False, None, None, 0
 
         config = self.config
@@ -173,7 +173,7 @@ class rfService():
                 elif 'text/xml' in contenttype:
                     # non-service schemas can use "text/xml" Content-Type
                     if inService:
-                        traverseLogger.warn(
+                        traverseLogger.warning(
                                 "Incorrect content type 'text/xml' for file within service {}".format(URILink))
                     decoded = response.text
                 else:

--- a/schema_pack.py
+++ b/schema_pack.py
@@ -46,7 +46,7 @@ def setup_schema_pack(uri, local_dir):
                 zf.close()
     except Exception as ex:
         my_logger.error("A problem when getting resource has occurred {}".format(uri))
-        my_logger.warn("output: ", exc_info=True)
+        my_logger.warning("output: ", exc_info=True)
     return True
 
 

--- a/validateRedfish.py
+++ b/validateRedfish.py
@@ -184,7 +184,7 @@ def validateComplex(service, sub_obj, prop_name, oem_check=True):
                 subCounts['failAdditional.complex'] += 1
                 subMsgs[key] = (displayValue(item), '-', '-', 'FAIL')
             else:
-                my_logger.warn('{} not defined in schema Complex {} {} (check version, spelling and casing)'
+                my_logger.warning('{} not defined in schema Complex {} {} (check version, spelling and casing)'
                                 .format(key, prop_name, sub_obj.Type))
                 subCounts['unverifiedAdditional.complex'] += 1
                 subMsgs[key] = (displayValue(item), '-', '-', 'FAIL')

--- a/validateResource.py
+++ b/validateResource.py
@@ -136,7 +136,7 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
                 my_logger.error('@odata.id of ReferenceableMember does not point to the correct object: {}'.format(odata_id))
                 counts['badOdataIdResolution'] += 1
         else:
-            my_logger.warn('No parent found with which to test @odata.id of ReferenceableMember')
+            my_logger.warning('No parent found with which to test @odata.id of ReferenceableMember')
     
     if service.config['uricheck']:
         my_uris = redfish_obj.Type.getUris()
@@ -226,7 +226,7 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
             counts['failAdditional'] += 1
             messages[key] = create_entry(key, displayValue(item), '-', '-', 'FAIL')
         else:
-            my_logger.warn('{} not defined in schema {} (check version, spelling and casing)'.format(key, SchemaNamespace))
+            my_logger.warning('{} not defined in schema {} (check version, spelling and casing)'.format(key, SchemaNamespace))
             counts['unverifiedAdditional'] += 1
             messages[key] = create_entry(key, displayValue(item), '-', '-', 'Additional')
 


### PR DESCRIPTION
It's an enhancement to use `logger.warning` instead of `logger.warn` (which is deprecated)