### PR TITLE
Remove beautifulsoup XML namespace lookups

### DIFF
--- a/common/catalog.py
+++ b/common/catalog.py
@@ -177,11 +177,11 @@ class SchemaDoc:
         self.classes = {}
         self.alias = {}
 
-        edmxTag = self.soup.find("edmx:Edmx", recursive=False)
-        reftags = edmxTag.find_all("edmx:Reference", recursive=False)
+        edmxTag = self.soup.find("Edmx", recursive=False)
+        reftags = edmxTag.find_all("Reference", recursive=False)
         self.refs = {}
         for ref in reftags:
-            includes = ref.find_all("edmx:Include", recursive=False)
+            includes = ref.find_all("Include", recursive=False)
             for item in includes:
                 uri = ref.get("Uri")
                 ns, alias = (item.get(x) for x in ["Namespace", "Alias"])
@@ -200,7 +200,7 @@ class SchemaDoc:
 
         cntref = len(self.refs)
 
-        parentTag = edmxTag.find("edmx:DataServices", recursive=False)
+        parentTag = edmxTag.find("DataServices", recursive=False)
         children = parentTag.find_all("Schema", recursive=False)
         self.classes = {}
         for child in children:

--- a/common/schema.py
+++ b/common/schema.py
@@ -134,8 +134,8 @@ def getSchemaDetailsLocal(SchemaType, SchemaURI, config):
 
         # get tags
         soup = BeautifulSoup(data, "xml")
-        edmxTag = soup.find('edmx:Edmx', recursive=False)
-        parentTag = edmxTag.find('edmx:DataServices', recursive=False)
+        edmxTag = soup.find('Edmx', recursive=False)
+        parentTag = edmxTag.find('DataServices', recursive=False)
         child = parentTag.find('Schema', recursive=False)
         SchemaNamespace = child['Namespace']
         FoundAlias = SchemaNamespace.split(".")[0]
@@ -186,10 +186,10 @@ def getReferenceDetails(soup, metadata_dict=None, name='xml'):
     includeTuple = namedtuple('include', ['Namespace', 'Uri'])
     refDict = {}
 
-    maintag = soup.find("edmx:Edmx", recursive=False)
-    reftags = maintag.find_all('edmx:Reference', recursive=False)
+    maintag = soup.find("Edmx", recursive=False)
+    reftags = maintag.find_all('Reference', recursive=False)
     for ref in reftags:
-        includes = ref.find_all('edmx:Include', recursive=False)
+        includes = ref.find_all('Include', recursive=False)
         for item in includes:
             uri = ref.get('Uri')
             ns, alias = (item.get(x) for x in ['Namespace', 'Alias'])


### PR DESCRIPTION
This is a cleaner version of #468 that was inadvertently closed (and as a contributor I don't think I can reopen).

This branch makes beautifulsoup ignore the namespace on schemas, and pull by only the tag name.