### PR TITLE
Make service validator executable directly

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright Notice:
 # Copyright 2016-2021 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Service-Validator/blob/master/LICENSE.md

--- a/RedfishServiceValidatorGui.py
+++ b/RedfishServiceValidatorGui.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright Notice:
 # Copyright 2016-2019 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Service-Validator/blob/master/LICENSE.md


### PR DESCRIPTION
On Linux systems, being able to execute the scripts directly both
informs users which python should be used, and allows less typing.