### PR TITLE
Fix bug in schema pack download

### DIFF
--- a/redfish_service_validator/RedfishServiceValidator.py
+++ b/redfish_service_validator/RedfishServiceValidator.py
@@ -134,7 +134,7 @@ def main(argslist=None, configfile=None):
     schemadir = args.schema_directory
 
     if not os.path.isdir(schemadir):
-        import schema_pack
+        from redfish_service_validator import schema_pack
         my_logger.info('Downloading initial schemas from online')
         my_logger.info('The tool will, by default, attempt to download and store XML files to relieve traffic from DMTF/service')
         schema_pack.my_logger.addHandler(file_handler)


### PR DESCRIPTION
Because of the conditional imports, when doing the name change from
common to redfish_service_validator, one import got missed.  This causes
a bug where, if the schema pack directory is empty, redfish service
validator fails with an ImportError.

This commit fixes the import.

Tested:
Deleting the SchemaPack and running the service validator no longer
fails.

Signed-off-by: Ed Tanous <edtanous@google.com>