### PR TITLE
Remove conditional imports

### DIFF
--- a/redfish_service_validator/config.py
+++ b/redfish_service_validator/config.py
@@ -4,6 +4,7 @@
 
 import configparser
 import logging
+import json
 
 my_logger = logging.getLogger()
 my_logger.setLevel(logging.DEBUG)
@@ -55,7 +56,6 @@ def convert_config_to_args(args, config):
                     else:
                         setattr(args, option, my_config[section][option])
     my_config_dict = config_parse_to_dict(my_config)
-    import json
     print(json.dumps(my_config_dict, indent=4))
         
 


### PR DESCRIPTION
Conditional imports, while useful in a minor way to save ram, lead to
situations where dependencies are harder to trace, and migrations are
harder to execute.

Python pep8 also says:
"Imports are always put at the top of the file, just after any module
comments and docstrings, and before module globals and constants."
https://peps.python.org/pep-0008/#imports

We should follow that advice.  This commit moves all imports to be at
the top of the file.

Signed-off-by: Ed Tanous <edtanous@google.com>