### PR TITLE
Generate error on missing @odata.id, misc fixes

### DIFF
--- a/RedfishServiceValidator.py
+++ b/RedfishServiceValidator.py
@@ -4,6 +4,8 @@
 # https://github.com/DMTF/Redfish-Service-Validator/blob/master/LICENSE.md
 
 from redfish_service_validator.RedfishServiceValidator import main
+import sys
 
 if __name__ == '__main__':
-    main()
+    status_code, lastResultsPage, exit_string = main()
+    sys.exit(status_code)

--- a/redfish_service_validator/RedfishServiceValidatorGui.py
+++ b/redfish_service_validator/RedfishServiceValidatorGui.py
@@ -19,7 +19,7 @@ import traceback
 import webbrowser
 
 import redfish_service_validator.RedfishLogo as logo
-import RedfishServiceValidator as rsv
+import redfish_service_validator.RedfishServiceValidator as rsv
 
 g_config_file_name = "config/config.ini"
 

--- a/redfish_service_validator/validateRedfish.py
+++ b/redfish_service_validator/validateRedfish.py
@@ -203,7 +203,7 @@ def validateComplex(service, sub_obj, prop_name, oem_check=True):
                 my_logger.warning('{} not defined in schema Complex {} {} (check version, spelling and casing)'
                                 .format(key, prop_name, sub_obj.Type))
                 subCounts['unverifiedAdditional.complex'] += 1
-                subMsgs[key] = (displayValue(item), '-', '-', 'FAIL')
+                subMsgs[key] = (displayValue(item), '-', '-', 'Additional')
             
             fuzz = get_fuzzy_property(key, sub_obj.properties)
             if fuzz != key and fuzz in sub_obj.properties:

--- a/redfish_service_validator/validateResource.py
+++ b/redfish_service_validator/validateResource.py
@@ -124,6 +124,15 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
 
     # verify odata_id properly resolves to its parent if holding fragment
     odata_id = me['payload'].get('@odata.id')
+    if odata_id is None:
+        # Do not error for namespace.type MessageRegistry.MessageRegistry, etc 
+        if any(['{}.{}'.format(x, x) in redfish_obj.Type.getTypeTree() for x in ['MessageRegistry', 'AttributeRegistry', 'PrivilegeRegistry']]):
+            my_logger.debug('No @odata.id was found in this resource, but not needed')
+        else:
+            my_logger.error('No @odata.id was found in this resource')
+            messages['@odata.id'] = create_entry('@odata.id', '-', '-', 'DNE', 'FAIL')
+            counts['errorMissingOdataId'] += 1
+
     if odata_id is not None and '#' in odata_id:
         if parent is not None:
             payload_resolve = navigateJsonFragment(parent.payload, URI)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -13,6 +13,11 @@ sys.path.append('../')
 
 import redfish_service_validator.catalog as catalog
 
+import logging
+
+logging.Logger.verbose1 =  logging.Logger.debug
+logging.Logger.verbose2 =  logging.Logger.debug
+
 class TestCatalog(unittest.TestCase):
     def test_fuzzy(self):
         print('\n')


### PR DESCRIPTION
Returns status code if running from console

Corrected GUI not importing right library

Moved 'FAIL' message to 'Additional' if additional property is not defined in Complex object

Report @odata.id is missing from payload

Small test error fixed

Fix #515 
Fix #514 