### PR TITLE
Added exception in '@odata.id' validation to allow for trailing slash discrepancy with the ServiceRoot resource

### DIFF
--- a/redfish_service_validator/helper.py
+++ b/redfish_service_validator/helper.py
@@ -155,7 +155,7 @@ def checkPayloadConformance(jsondata, uri):
             if not paramPass:
                 my_logger.error("{} {}: Expected format is /path/to/uri, but received: {}".format(uri, key, decoded[key]))
             else:
-                if uri != '' and decoded[key] != uri:
+                if uri != '' and decoded[key] != uri and not (uri == "/redfish/v1/" and decoded[key] == "/redfish/v1"):
                     my_logger.warning("{} {}: Expected @odata.id to match URI link {}".format(uri, key, decoded[key]))
         elif odata_name == 'odata.count':
             paramPass = isinstance(decoded[key], int)


### PR DESCRIPTION
Fix #530 

Only allowing this for the ServiceRoot resource since it's an oddly defined one from 1.0 where it has two well-known URIs (/redfish/v1/ and /redfish/v1), and services can implement this in a manner where they serve the same static file.