### PR TITLE
Remove uri_check toggling for inAnnotation variable

### DIFF
--- a/redfish_service_validator/catalog.py
+++ b/redfish_service_validator/catalog.py
@@ -923,6 +923,7 @@ class RedfishObject(RedfishProperty):
 
             # Validate our Uri
             sub_obj.HasValidUri = True
+            sub_obj.HasValidUriStrict = True
             allowable_uris = sub_obj.Type.getUris()
             # If we have expected URIs and @odata.id
             # And we AREN'T a navigation property

--- a/redfish_service_validator/validateResource.py
+++ b/redfish_service_validator/validateResource.py
@@ -163,7 +163,7 @@ def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=
                 if not redfish_obj.HasValidUriStrict and redfish_obj.payload.get('Id') is not None:
                     counts['failRedfishUriStrict'] += 1
                     messages['@odata.id'].result = 'FAIL'
-                    my_logger.error('URI {} does not match object ID of resource'.format(odata_id, redfish_obj.Type))
+                    my_logger.error('The Id property does not match the last segment of the URI {}'.format(odata_id))
             else:
                 if '/Oem/' in odata_id:
                     counts['warnRedfishUri'] += 1

--- a/redfish_service_validator/validateResource.py
+++ b/redfish_service_validator/validateResource.py
@@ -302,11 +302,7 @@ def validateURITree(service, URI, uriName, expectedType=None, expectedJson=None,
 
     refLinks = []
 
-    if inAnnotation and service.config['uricheck']:
-        service.catalog.flags['ignore_uri_checks'] = True
     validateSuccess, counts, results, links, thisobj = validateSingleURI(service, URI, uriName, expectedType, expectedJson, parent)
-    if inAnnotation and service.config['uricheck']:
-        service.catalog.flags['ignore_uri_checks'] = False
 
     # If successful and a MessageRegistryFile...
     if validateSuccess and 'MessageRegistryFile.MessageRegistryFile' in thisobj.Type.getTypeTree():


### PR DESCRIPTION
Removes portion of code that removes URI checking on specific instances of "inAnnotation" variable being set to True, which occurs when URIs exist in particular contexts (this would toggle `ignore_uri_checks`).  This should not ignore URIChecks, and correctly set variables for standard URIs.

However, the reason for this code to exist is not explained, nor is it practical as it applies on a first-come basis, which labels some URIs as based on Annotations when they are standard URIs.

Also adds a line which makes StrictURI flag true outside of the UriCheck block, which only affects the program if `ignore_uri_checks` was True.

Fixes #538 