### PR TITLE
Added handling of cases where a payload annotation's definition cannot be located in schema files

### DIFF
--- a/redfish_service_validator/catalog.py
+++ b/redfish_service_validator/catalog.py
@@ -1013,13 +1013,16 @@ class RedfishObject(RedfishProperty):
                 if getNamespace(fullItem) not in allowed_annotations:
                     my_logger.warning("getAnnotations: {} is not an allowed annotation namespace, please check spelling/capitalization.".format(fullItem))
                     continue
-                type_obj = sub_obj.Type.catalog.getSchemaInCatalog(fullItem).terms[getType(fullItem)]
-                if type_obj.getBaseType()[0] == 'complex':
-                    object = RedfishObject(type_obj, name=key, parent=self)
-                else:
-                    object = RedfishProperty(type_obj, name=key, parent=self)
-                my_logger.verbose1(('Adding Additional', key, my_odata_type, sub_obj.Type))
-                sub_obj.properties[key] = object.populate(sub_payload[key])
+                try:
+                    type_obj = sub_obj.Type.catalog.getSchemaInCatalog(fullItem).terms[getType(fullItem)]
+                    if type_obj.getBaseType()[0] == 'complex':
+                        object = RedfishObject(type_obj, name=key, parent=self)
+                    else:
+                        object = RedfishProperty(type_obj, name=key, parent=self)
+                    my_logger.verbose1(('Adding Additional', key, my_odata_type, sub_obj.Type))
+                    sub_obj.properties[key] = object.populate(sub_payload[key])
+                except:
+                    my_logger.warning("Unable to locate the definition of the annotation '@{}'.".format(fullItem))
 
             evals.append(sub_obj)
         if not isinstance(payload, list):

--- a/redfish_service_validator/catalog.py
+++ b/redfish_service_validator/catalog.py
@@ -1022,7 +1022,7 @@ class RedfishObject(RedfishProperty):
                     my_logger.verbose1(('Adding Additional', key, my_odata_type, sub_obj.Type))
                     sub_obj.properties[key] = object.populate(sub_payload[key])
                 except:
-                    my_logger.warning("Unable to locate the definition of the annotation '@{}'.".format(fullItem))
+                    my_logger.error("Unable to locate the definition of the annotation '@{}'.".format(fullItem))
 
             evals.append(sub_obj)
         if not isinstance(payload, list):


### PR DESCRIPTION
Fix #547 

Currently only reporting a warning instead of an error; may need to discuss this a bit since using undefined annotation is illegal, but could be detrimental for cases like this.