### PR TITLE
Added check to ensure the '@odata.id' value is a string before trying to follow the link

### DIFF
--- a/redfish_service_validator/validateResource.py
+++ b/redfish_service_validator/validateResource.py
@@ -391,6 +391,12 @@ def validateURITree(service, URI, uriName, expectedType=None, expectedJson=None,
                 results[uriName]['errors'] += '\n' + errmsg
                 counts['errorMissingRefOdata'] += 1
                 continue
+            elif not isinstance(link_destination, str):
+                errmsg = 'URI for NavigationProperty is not a string {} {} {}'.format(link_destination, link.Name, link.parent)
+                my_logger.error(errmsg)
+                results[uriName]['errors'] += '\n' + errmsg
+                counts['errorInvalidReferenceObject'] += 1
+                continue
             elif link_destination.split('#')[0].endswith('/'):
                 # (elegantly) add warn message to resource html
                 warnmsg = 'Referenced URI acquired ends in slash: {}'.format(link_destination)


### PR DESCRIPTION
Encountered a conformance issue where `@odata.id` for a handful of properties was not a string, but instead was an array of strings. This would cause the tool to crash. Change added to log an error and move on with testing.