### PR TITLE
Made change to allow for action names to be annotated

### DIFF
--- a/redfish_service_validator/validateRedfish.py
+++ b/redfish_service_validator/validateRedfish.py
@@ -254,6 +254,8 @@ def validateComplex(service, sub_obj, prop_name, oem_check=True):
         #         my_actions.append((new_act_name, REDFISH_ABSENT))
 
         for act_name, actionDecoded in my_actions:
+            if '@' in act_name:
+                continue
             act_schema = sub_obj.Type.catalog.getSchemaDocByClass(getNamespace(act_name))
             act_class = act_schema.classes.get(getNamespace(act_name))
 


### PR DESCRIPTION
Would like to see if others agree with this, but this came up when someone was attempting to show an action is deprecated in an OEM resource. For example, the desire was to have an actions property like this:

```
{
    "Actions": {
        "#ContosoManager.SuperCoolAction": {
            "target": "/redfish/v1/Oem/Contoso/Manager/Actions/ContosoManager.SuperCoolAction"
        },
        "#ContosoManager.SuperCoolAction@Redfish.Deprecated": "This action has been deprecated for newer actions"
    }
}
```

Using `@Redfish.Deprecated` inside of the Actions object wasn't being handled, as it was expecting everything to be an object.