### PR TITLE
Added breakout condition when tracing a definition's type tree to prevent hangs due to invalid schemas with type loops

### DIFF
--- a/redfish_service_validator/catalog.py
+++ b/redfish_service_validator/catalog.py
@@ -536,13 +536,18 @@ class RedfishType:
         """
         tree = [self]
         my_type = self.parent_type
+        my_logger.error("560DEBUG: getTypeTree ENTRANCE, my_type '{}'".format(my_type))
         while my_type:
             if 'Edm.' not in my_type:
+                my_logger.error("560DEBUG: getTypeTree Looking up parent '{}'".format(my_type))
                 type_obj = self.owner.parent_doc.catalog.getSchemaDocByClass(my_type).getTypeInSchemaDoc(my_type)
                 tree.append(type_obj)
+                my_logger.error("560DEBUG: getTypeTree Found parent '{}'".format(type_obj.parent_type))
                 my_type = type_obj.parent_type
             else:
+                my_logger.error("560DEBUG: getTypeTree EXIT 1, '{}'".format(tree + [my_type]))
                 return tree + [my_type]
+        my_logger.error("560DEBUG: getTypeTree EXIT 2, '{}'".format(tree))
         return tree
 
     def getBaseType(self):
@@ -839,6 +844,7 @@ class RedfishObject(RedfishProperty):
         self.HasValidUri = False
         self.HasValidUriStrict = False
         self.properties = {}
+        my_logger.error("560DEBUG: RedfishObject, redfish_type '{}', name '{}', parent '{}'".format(redfish_type, name, parent))
         for prop, typ in redfish_type.getProperties().items():
             try:
                 base = typ.getBaseType()
@@ -854,6 +860,7 @@ class RedfishObject(RedfishProperty):
         """
         Return a populated object, or list of objects
         """
+        my_logger.error("560DEBUG: populate, payload '{}', check '{}', casted '{}'".format(payload, check, casted))
         populated_object = super().populate(payload)
         populated_object.payload = payload
 

--- a/redfish_service_validator/catalog.py
+++ b/redfish_service_validator/catalog.py
@@ -536,18 +536,18 @@ class RedfishType:
         """
         tree = [self]
         my_type = self.parent_type
-        my_logger.error("560DEBUG: getTypeTree ENTRANCE, my_type '{}'".format(my_type))
-        while my_type:
+        # 1000 seems to be a reasonable number to handle cases where a schema has lots of minor and errata versions in its tree (like Chassis or ComputerSystem)
+        break_out = 1000
+        while my_type and break_out != 0:
+            break_out = break_out - 1
             if 'Edm.' not in my_type:
-                my_logger.error("560DEBUG: getTypeTree Looking up parent '{}'".format(my_type))
                 type_obj = self.owner.parent_doc.catalog.getSchemaDocByClass(my_type).getTypeInSchemaDoc(my_type)
                 tree.append(type_obj)
-                my_logger.error("560DEBUG: getTypeTree Found parent '{}'".format(type_obj.parent_type))
                 my_type = type_obj.parent_type
             else:
-                my_logger.error("560DEBUG: getTypeTree EXIT 1, '{}'".format(tree + [my_type]))
                 return tree + [my_type]
-        my_logger.error("560DEBUG: getTypeTree EXIT 2, '{}'".format(tree))
+        if break_out == 0:
+            my_logger.error("Schema definition for '{}' contained too many base type references; check its schema definition for loops".format(self.fulltype))
         return tree
 
     def getBaseType(self):
@@ -844,7 +844,6 @@ class RedfishObject(RedfishProperty):
         self.HasValidUri = False
         self.HasValidUriStrict = False
         self.properties = {}
-        my_logger.error("560DEBUG: RedfishObject, redfish_type '{}', name '{}', parent '{}'".format(redfish_type, name, parent))
         for prop, typ in redfish_type.getProperties().items():
             try:
                 base = typ.getBaseType()
@@ -860,7 +859,6 @@ class RedfishObject(RedfishProperty):
         """
         Return a populated object, or list of objects
         """
-        my_logger.error("560DEBUG: populate, payload '{}', check '{}', casted '{}'".format(payload, check, casted))
         populated_object = super().populate(payload)
         populated_object.payload = payload
 

--- a/redfish_service_validator/validateResource.py
+++ b/redfish_service_validator/validateResource.py
@@ -48,7 +48,6 @@ def get_my_capture(this_logger, handler):
 def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=None, parent=None):
     # rs-assertion: 9.4.1
     # Initial startup here
-    my_logger.error("560DEBUG: validateSingleURI, URI '{}', uriName '{}'".format(URI, uriName))
     my_logger.verbose1("\n*** %s, %s", uriName, URI)
     my_logger.info("\n*** %s", URI)
     my_logger.verbose1("\n*** {}, {}".format(expectedType, expectedJson is not None))
@@ -296,7 +295,6 @@ def validateURITree(service, URI, uriName, expectedType=None, expectedJson=None,
     #   valid links come from getAllLinks, includes info such as expected values, etc
     #   as long as it is able to pass that info, should not crash
     # If this is our first called URI
-    my_logger.error("560DEBUG: validateURITree, URI '{}', uriName '{}'".format(URI, uriName))
     top = allLinks is None
     if top: allLinks = set()
     allLinks.add(URI)

--- a/redfish_service_validator/validateResource.py
+++ b/redfish_service_validator/validateResource.py
@@ -48,6 +48,7 @@ def get_my_capture(this_logger, handler):
 def validateSingleURI(service, URI, uriName='', expectedType=None, expectedJson=None, parent=None):
     # rs-assertion: 9.4.1
     # Initial startup here
+    my_logger.error("560DEBUG: validateSingleURI, URI '{}', uriName '{}'".format(URI, uriName))
     my_logger.verbose1("\n*** %s, %s", uriName, URI)
     my_logger.info("\n*** %s", URI)
     my_logger.verbose1("\n*** {}, {}".format(expectedType, expectedJson is not None))
@@ -295,6 +296,7 @@ def validateURITree(service, URI, uriName, expectedType=None, expectedJson=None,
     #   valid links come from getAllLinks, includes info such as expected values, etc
     #   as long as it is able to pass that info, should not crash
     # If this is our first called URI
+    my_logger.error("560DEBUG: validateURITree, URI '{}', uriName '{}'".format(URI, uriName))
     top = allLinks is None
     if top: allLinks = set()
     allLinks.add(URI)


### PR DESCRIPTION
Fix #560 

I originally considered using a simple "if current type == base type" to be the check, but that would help if the base type loop is larger. So, I opted to use a max loop count to cover more complicated schema definition loop conditions.