### PR TITLE
Break out of object schema mapping if not an object

### DIFF
--- a/redfish_service_validator/catalog.py
+++ b/redfish_service_validator/catalog.py
@@ -905,6 +905,7 @@ class RedfishObject(RedfishProperty):
             populated_object.HasValidUri = True
             populated_object.HasValidUriStrict = False
             populated_object.properties = {x: y.populate(REDFISH_ABSENT) for x, y in populated_object.properties.items()}
+            return populated_object
 
         # Cast types if they're below their parent or are OemObjects
         # Don't cast objects with odata.type that matches their current object type


### PR DESCRIPTION
Found an issue related to mapping objects to schema definitions. This comes up in particular when an OEM extension is not providing `@odata.type`. The tool tries to dynamically map a definition and keep stepping into properties, but hits a point where it will break down on leaf properties. The change adds a missing return statement when it finds the property is not an object; not returning there guarantees an exception when it tries to pull out its `@odata.type` property.

Long term it might be worth rechecking this flow to not even attempt to map it in the first place, but that might take more time than its worth at the moment.