### PR TITLE
Fixed link verification to ensure the linked resource is of the expected data type

### DIFF
--- a/redfish_service_validator/validateRedfish.py
+++ b/redfish_service_validator/validateRedfish.py
@@ -155,7 +155,11 @@ def validateEntity(service, prop, val, parentURI=""):
         else:
             my_target_type = my_target_schema.getTypeInSchemaDoc(my_target_type)
             all_target_types = [str(x) for x in my_target_type.getTypeTree()]
-            if any(x in my_type_chain for x in all_target_types):
+            expect_type = stripCollection(prop.Type.fulltype)
+            if expect_type not in all_target_types:
+                my_logger.error('{}: Linked resource is not the correct type; found {}, expected {}' .format(name.split(':')[-1], my_target_type, expect_type))
+                return False
+            elif any(x in my_type_chain for x in all_target_types):
                 return True
             else:
                 my_logger.error('{}: Linked resource reports version {} not in Typechain' .format(name.split(':')[-1], my_target_type))

--- a/redfish_service_validator/validateRedfish.py
+++ b/redfish_service_validator/validateRedfish.py
@@ -156,7 +156,7 @@ def validateEntity(service, prop, val, parentURI=""):
             my_target_type = my_target_schema.getTypeInSchemaDoc(my_target_type)
             all_target_types = [str(x) for x in my_target_type.getTypeTree()]
             expect_type = stripCollection(prop.Type.fulltype)
-            if expect_type not in all_target_types:
+            if expect_type not in all_target_types and my_target_type != 'Resource.Item':
                 my_logger.error('{}: Linked resource is not the correct type; found {}, expected {}' .format(name.split(':')[-1], my_target_type, expect_type))
                 return False
             elif any(x in my_type_chain for x in all_target_types):


### PR DESCRIPTION
Found a gap in testing where if a linked resource is of the incorrect data type (like if AccountService in /redfish/v1/ points to a SessionService resource).