### PR TITLE
Added requesttimeout and requestattempts arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ At a minimum, the `ip`, `username`, and `password` options must be modified.
 ### [Validator]
 
 | Variable           | CLI Argument         | Type    | Definition |
-| :---               | :---                 | :---    | :---       |
+| :---               | :---                 |:--------| :---       |
 | `payload`          | `--payload`          | string  | The mode to validate payloads ('Tree', 'Single', 'SingleFile', or 'TreeFile') followed by resource/filepath; see below. |
 | `logdir`           | `--logdir`           | string  | The directory for generated report files; default: 'logs'. |
 | `oemcheck`         | `--nooemcheck`       | boolean | Whether to check OEM items on service; 'True' or 'False'. |
@@ -88,6 +88,8 @@ At a minimum, the `ip`, `username`, and `password` options must be modified.
 | `schema_directory` | `--schema_directory` | string  | Directory for local schema files. |
 | `mockup`           | `--mockup`           | string  | Directory tree for local mockup files.  This option enables insertion of local mockup resources to replace missing, incomplete, or incorrect implementations retrieved from the service that may hinder full validation coverage. |
 | `collectionlimit`  | `--collectionlimit`  | string  | Sets a limit to links gathered from collections by type (schema name).<br/>Example 1: `ComputerSystem 20` limits ComputerSystemCollection to 20 links.<br/>Example 2: `ComputerSystem 20 LogEntry 10` limits ComputerSystemCollection to 20 links and LogEntryCollection to 10 links. |
+| `requesttimeout`   | `--requesttimeout`   | integer | Timeout in seconds for HTTP request waiting for response. |
+| `requestattempts`  | `--requestattempts`  | integer | Number of attempts after failed HTTP requests. |
 
 ### Payload Option
 

--- a/redfish_service_validator/RedfishServiceValidator.py
+++ b/redfish_service_validator/RedfishServiceValidator.py
@@ -80,6 +80,8 @@ def validate(argslist=None, configfile=None):
     argget.add_argument('--schema_directory', type=str, default='./SchemaFiles/metadata', help='Directory for local schema files')
     argget.add_argument('--mockup', type=str, default='', help='Enables insertion of local mockup resources to replace missing, incomplete, or incorrect implementations retrieved from the service that may hinder full validation coverage')
     argget.add_argument('--collectionlimit', type=str, default=['LogEntry', '20'], help='apply a limit to collections (format: RESOURCE1 COUNT1 RESOURCE2 COUNT2...)', nargs='+')
+    argget.add_argument('--requesttimeout', type=int, default=10, help='Timeout in seconds for HTTP requests waiting for response')
+    argget.add_argument('--requestattempts', type=int, default=10, help='Number of attempts after failed HTTP requests')
 
     # parse...
     args = argget.parse_args(argslist)

--- a/redfish_service_validator/config.py
+++ b/redfish_service_validator/config.py
@@ -12,7 +12,7 @@ my_logger.setLevel(logging.DEBUG)
 config_struct = {
     'Tool': ['verbose'],
     'Host': ['ip', 'username', 'password', 'description', 'forceauth', 'authtype', 'token', 'ext_http_proxy', 'ext_https_proxy', 'serv_http_proxy', 'serv_https_proxy'],
-    'Validator': ['payload', 'logdir', 'oemcheck', 'debugging', 'schema_directory', 'uricheck', 'mockup', 'collectionlimit']
+    'Validator': ['payload', 'logdir', 'oemcheck', 'debugging', 'schema_directory', 'uricheck', 'mockup', 'collectionlimit', 'requesttimeout', 'requestattempts']
 }
 
 config_options = [x for name in config_struct for x in config_struct[name]]
@@ -53,6 +53,8 @@ def convert_config_to_args(args, config):
                 elif my_config[section][option] not in ['', None]:
                     if option.lower() == 'payload' or option.lower() == 'collectionlimit':
                         setattr(args, option, my_config[section][option].split(' '))
+                    elif option.lower() in ['requesttimeout', 'requestattempts']:
+                        setattr(args, option, int(my_config[section][option]))
                     else:
                         setattr(args, option, my_config[section][option])
                     if option.lower() in ['password', 'token']:

--- a/redfish_service_validator/traverse.py
+++ b/redfish_service_validator/traverse.py
@@ -47,7 +47,6 @@ class rfService():
         self.config['usessl'] = urlparse(self.config['configuri']).scheme in ['https']
         self.config['certificatecheck'] = False
         self.config['certificatebundle'] = None
-        self.config['timeout'] = 10
 
         # NOTE: this is a validator limitation.  maybe move this to its own config
         if self.config['collectionlimit']:
@@ -75,7 +74,7 @@ class rfService():
             self.ext_proxies = {}
             if self.config['ext_http_proxy'] != '': self.ext_proxies['http'] = self.config['ext_http_proxy']
             if self.config['ext_https_proxy'] != '': self.ext_proxies['https'] = self.config['ext_https_proxy']
-        self.context = rf.redfish_client(base_url=rhost, username=user, password=passwd, timeout=self.config['timeout'], proxies=proxies)
+        self.context = rf.redfish_client(base_url=rhost, username=user, password=passwd, timeout=self.config['requesttimeout'], max_retry=self.config['requestattempts'], proxies=proxies)
         self.context.login( auth = self.config['authtype'].lower() )
 
         # Go through $metadata and download any additional schema files needed
@@ -135,7 +134,7 @@ class rfService():
         config = self.config
         # proxies = self.proxies
         ConfigIP, UseSSL, AuthType, ChkCert, ChkCertBundle, timeout, Token = config['configuri'], config['usessl'], config['authtype'], \
-                config['certificatecheck'], config['certificatebundle'], config['timeout'], config['token']
+                config['certificatecheck'], config['certificatebundle'], config['requesttimeout'], config['token']
 
         scheme, netloc, path, params, query, fragment = urlparse(link_uri)
         inService = scheme == '' and netloc == ''


### PR DESCRIPTION
This PR introduces configurable parameters for HTTP request timeout (--requesttimeout) and retry attempts (--requestattempts).
The current static values for request timeouts and retries may not fit all environments, especially where network reliability or response times vary. I encountered this need during my usage of the tool and implemented this solution to improve usability.

**Changes**

1. Added `--requesttimeout` parameter to set the timeout in seconds for HTTP requests.
2. Added `--requestattempts` parameter to set the number of retry attempts after failed HTTP requests.
3. Updated `convert_config_to_args` func to convert these parameters to integer.
4. Updated the documentation to include descriptions of the new parameters.

Also addressed to #577 

Fix #577 