### PR TITLE
Corrected regex pattern for date-time properties

### DIFF
--- a/redfish_service_validator/catalog.py
+++ b/redfish_service_validator/catalog.py
@@ -792,7 +792,7 @@ class RedfishProperty(object):
 
         elif my_type == "Edm.DateTimeOffset":
             return RedfishProperty.validate_string(
-                val, r".*(Z|(\+|-)[0-9][0-9]:[0-9][0-9])")
+                val, r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(\+|-)\d{2}:\d{2})")
 
         elif my_type == "Edm.Duration":
             return RedfishProperty.validate_string(


### PR DESCRIPTION
Upon visual inspection of some services, I noticed instances where date-time properties were not following ISO8601's format (such as missing a leading zero in the month). I found that the regex pattern we're using today allows for any format prior to the offset portion of the date-time value.