### PR TITLE
fix: show all ActionInfo entries in HTML logs

### DIFF
--- a/redfish_service_validator/catalog.py
+++ b/redfish_service_validator/catalog.py
@@ -1108,10 +1108,10 @@ class RedfishObject(RedfishProperty):
                     if n == 'Actions':
                         new_type = item.Type.catalog.getTypeInCatalog('ActionInfo.ActionInfo')
                         act_iter = self.act_iterator(item.Value)
-                        for act in act_iter:
+                        for num, act in enumerate(act_iter):
                             uri = act.get('@Redfish.ActionInfo')
                             if isinstance(uri, str):
-                                my_link = RedfishObject(new_type, 'ActionInfo', item).populate({'@odata.id': uri})
+                                my_link = RedfishObject(new_type, 'ActionInfo#{}'.format(num), item).populate({'@odata.id': uri})
                                 my_link.InAnnotation = True
                                 links.append(my_link)
                     if item.Type.IsNav:


### PR DESCRIPTION
- ActionInfo links in HTML logs are currently missing because:
  - getLinks (catalog.py:1114) assigns the same Name ('ActionInfo') to each ActionInfo link
  - Subsequent links overwrite previous ones, sharing the same uriName
  - validateURITree returns only the last link

- Fixed by:
  - Enumerating the generator (catalog.py:1111) to get a unique index (num)
  - Adding the index to the 'ActionInfo' string to form each unique link name