### PR TITLE
Add OriginOfConditionUnavailable handling for OriginOfCondition in LogEntry

### DIFF
--- a/redfish_service_validator/system_under_test.py
+++ b/redfish_service_validator/system_under_test.py
@@ -456,6 +456,10 @@ class SystemUnderTest(object):
                 if item == "Oem" and self._no_oem:
                     continue
 
+                # Skip OriginOfCondition
+                if item == "OriginOfCondition":
+                    continue
+
                 # If the item is a reference, go to the resource
                 if (
                     item == "@odata.id"

--- a/redfish_service_validator/system_under_test.py
+++ b/redfish_service_validator/system_under_test.py
@@ -83,6 +83,7 @@ class SystemUnderTest(object):
         self._resources = {}
         self._annotation_uris = []
         self._collection_capabilities_uris = []
+        self._excluded_uris = []
 
         # Build collection limits
         self._collection_limits = {}
@@ -255,6 +256,16 @@ class SystemUnderTest(object):
             A boolean indicating if the URI is from a collection capabilities annotation
         """
         return uri in self._collection_capabilities_uris
+
+    def exclude_uri_from_validation(self, uri):
+        """
+        Marks a URI to be excluded from validation
+
+        Args:
+            uri: The URI to exclude
+        """
+        if uri not in self._excluded_uris:
+            self._excluded_uris.append(uri)
 
     def get_resource(self, uri):
         """
@@ -499,6 +510,9 @@ class SystemUnderTest(object):
         resource = self.get_resource(uri)
         if resource["Validated"]:
             # Already tested
+            return
+        if uri in self._excluded_uris:
+            # URI is excluded from validation
             return
         logger.log_print("Validating {}...".format(uri))
 

--- a/redfish_service_validator/validate.py
+++ b/redfish_service_validator/validate.py
@@ -582,6 +582,33 @@ def validate_value(sut, uri, payload, prop_name, value, resource_type, obj_def, 
                     if value["@odata.id"].startswith("/") and "#" not in value["@odata.id"]:
                         # Get the referenced resource
                         resource = sut.get_resource(value["@odata.id"])
+
+                        # Special handling for OriginOfCondition with 404 responses
+                        if prop_name == "OriginOfCondition":
+                            origin_unavailable = payload.get("OriginOfConditionUnavailable")
+
+                            # Case 1: OriginOfConditionUnavailable is true - skip validation entirely
+                            if origin_unavailable is True:
+                                return pass_or_deprecated(value_deprecated_ver)
+
+                            # Check if the resource returned 404
+                            if resource["Response"] is not None:
+                                status_code = resource["Response"].status
+                                if status_code == 404:
+                                    # Case 2: OriginOfConditionUnavailable is false but got 404 - ERROR
+                                    if origin_unavailable is False:
+                                        return (
+                                            "FAIL",
+                                            "Reference Object Error: OriginOfCondition received HTTP {} but OriginOfConditionUnavailable is false (link should be available).".format(status_code)
+                                        )
+
+                                    # Case 3: OriginOfConditionUnavailable doesn't exist and got 404 - WARNING
+                                    else:
+                                        return (
+                                            "WARN",
+                                            "Reference Link Warning: OriginOfCondition received HTTP {} when accessing the URI (resource may be deleted/expired).".format(status_code)
+                                        )
+
                         link_payload, result = validate_response(resource)
                         if link_payload is None:
                             return result

--- a/redfish_service_validator/validate.py
+++ b/redfish_service_validator/validate.py
@@ -582,6 +582,38 @@ def validate_value(sut, uri, payload, prop_name, value, resource_type, obj_def, 
                     if value["@odata.id"].startswith("/") and "#" not in value["@odata.id"]:
                         # Get the referenced resource
                         resource = sut.get_resource(value["@odata.id"])
+
+                        # Special handling for OriginOfCondition with 404 responses
+                        if prop_name == "OriginOfCondition":
+                            origin_unavailable = payload.get("OriginOfConditionUnavailable")
+
+                            # Case 1: OriginOfConditionUnavailable is true - skip validation entirely
+                            if origin_unavailable is True:
+                                # Exclude from validation to prevent separate validation attempt
+                                sut.exclude_uri_from_validation(value["@odata.id"])
+                                return pass_or_deprecated(value_deprecated_ver)
+
+                            # Check if the resource returned 404
+                            if resource["Response"] is not None:
+                                status_code = resource["Response"].status
+                                if status_code == 404:
+                                    # Exclude from validation to prevent separate validation attempt
+                                    sut.exclude_uri_from_validation(value["@odata.id"])
+
+                                    # Case 2: OriginOfConditionUnavailable is false but got 404 - ERROR
+                                    if origin_unavailable is False:
+                                        return (
+                                            "FAIL",
+                                            "Reference Object Error: OriginOfCondition received HTTP {} but OriginOfConditionUnavailable is false (link should be available).".format(status_code)
+                                        )
+
+                                    # Case 3: OriginOfConditionUnavailable doesn't exist and got 404 - WARNING
+                                    else:
+                                        return (
+                                            "WARN",
+                                            "Reference Link Warning: OriginOfCondition received HTTP {} when accessing the URI (resource may be deleted/expired).".format(status_code)
+                                        )
+
                         link_payload, result = validate_response(resource)
                         if link_payload is None:
                             return result


### PR DESCRIPTION
This change addresses 404 errors when validating OriginOfCondition links in LogEntry resources that point to deleted or expired resources (such as Sessions).

The OriginOfConditionUnavailable property was added to LogEntry to handle situations where the OriginOfCondition link is no longer available. This implementation adds proper validation logic for this property:

- If OriginOfConditionUnavailable is true, skip checking the link
- If OriginOfConditionUnavailable is false and OriginOfCondition returns 404, log as ERROR (property contradicts the actual state)
- If OriginOfConditionUnavailable does not exist and OriginOfCondition returns 404, log as WARNING (backward compatibility for services that don't support this property)

URIs that are skipped are added to an exclusion list to prevent them from being validated as standalone resources.

This allows the validator to handle services where resources like sessions expire or logs rotate during validation without generating false failures.

Fixes #655

Signed-off-by: VinothKumar Shanmugavel <vinothkumars@ami.com>