### PR TITLE
Added '--skipschema' option to skip schema downloading and use already cached schema files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ usage: RedfishServiceValidator.py [-h] --user USER --password PASSWORD --rhost
                                   [--mockup MOCKUP]
                                   [--collectionlimit COLLECTIONLIMIT [COLLECTIONLIMIT ...]]
                                   [--nooemcheck] [--timeout TIMEOUT]
-                                  [--debugging]
+                                  [--skipschema] [--debugging]
 
 Validate Redfish services against schemas
 
@@ -102,6 +102,8 @@ options:
   --timeout TIMEOUT, -timeout TIMEOUT
                         The timeout, in seconds, for the service to respond to
                         HTTP requests
+  --skipschema          Skip downloading schema files and use only cached
+                        schemas in the schema directory
   --debugging           Controls the verbosity of the debugging output; if not
                         specified only INFO and higher are logged
 ```

--- a/redfish_service_validator/console_scripts.py
+++ b/redfish_service_validator/console_scripts.py
@@ -90,6 +90,11 @@ def main():
         help="The timeout, in seconds, for the service to respond to HTTP requests",
     )
     argget.add_argument(
+        "--skipschema",
+        action="store_true",
+        help="Skip downloading schema files and use only cached schemas in the schema directory",
+    )
+    argget.add_argument(
         "--debugging",
         action="store_true",
         help="Controls the verbosity of the debugging output; if not specified only INFO and higher are logged",
@@ -158,8 +163,11 @@ def run_validator(args):
         return 1, None
 
     # Update the schema cache
-    schema_pack.update_dsp8010_files(args["schema_directory"], proxies)
-    schema_pack.update_service_metadata(args["schema_directory"], sut.session, proxies)
+    if not args["skipschema"]:
+        schema_pack.update_dsp8010_files(args["schema_directory"], proxies)
+        schema_pack.update_service_metadata(args["schema_directory"], sut.session, proxies)
+    else:
+        logger.log_print("Skipping schema download; using cached schemas only\n")
 
     # Build the schema database
     metadata.parse_schema_files(args["schema_directory"])

--- a/redfish_service_validator/gui.py
+++ b/redfish_service_validator/gui.py
@@ -87,6 +87,12 @@ g_config_defaults = {
             "options": ["True", "False"],
             "destination": "nooemcheck",
         },
+        "Skip Schema": {
+            "value": "False",
+            "description": "Skip downloading schema files and use only cached schemas in the schema directory",
+            "options": ["True", "False"],
+            "destination": "skipschema",
+        },
         "Debugging": {
             "value": "False",
             "description": "Controls the verbosity of the debugging output",


### PR DESCRIPTION
New feature to optimize test time if needed. Can also be used when debugging schema files to prevent them from being overwritten.