### PR TITLE
Add configuration file support for enhanced usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,53 @@ If installing from GitHub, you may install the external packages by running:
 
 ## Usage
 
+The Redfish Service Validator can be configured using either command-line arguments or a configuration file (config.ini).
+
+### Configuration File
+
+You can use a `config.ini` file in the current working directory with your settings. This is useful for repeated operations with the same configuration.
+
+Example `config.ini`:
+
+```ini
+[Authentication]
+user = username
+password = password
+authtype = Session
+
+[Connection]
+rhost = https://RedfishIP
+timeout = 30
+
+[Proxy]
+ext_http_proxy = 
+ext_https_proxy = 
+
+[Paths]
+logdir = logs
+schema_directory = SchemaFiles
+
+[Validation]
+collectionlimit = LogEntry 20
+nooemcheck = false
+skipschema = false
+debugging = false
 ```
-usage: RedfishServiceValidator.py [-h] --user USER --password PASSWORD --rhost
-                                  RHOST [--authtype {Basic,Session}]
+
+To use a configuration file in a different location, use the `--config` option:
+
+```bash
+python RedfishServiceValidator.py --config /path/to/myconfig.ini
+```
+
+**Note:** Command-line arguments always override configuration file settings, ensuring backward compatibility.
+
+### Command-Line Arguments
+
+```
+usage: RedfishServiceValidator.py [-h] [--config CONFIG] [--user USER]
+                                  [--password PASSWORD] [--rhost RHOST]
+                                  [--authtype {Basic,Session}]
                                   [--ext_http_proxy EXT_HTTP_PROXY]
                                   [--ext_https_proxy EXT_HTTPS_PROXY]
                                   [--serv_http_proxy SERV_HTTP_PROXY]
@@ -62,8 +106,10 @@ usage: RedfishServiceValidator.py [-h] --user USER --password PASSWORD --rhost
 
 Validate Redfish services against schemas
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
+  --config CONFIG, -c CONFIG
+                        Path to configuration file; default: 'config.ini'
   --user USER, -u USER, -user USER, --username USER
                         The username for authentication
   --password PASSWORD, -p PASSWORD
@@ -108,10 +154,35 @@ options:
                         specified only INFO and higher are logged
 ```
 
+**Note:** The `--user`, `--password`, and `--rhost` arguments are required if not provided in the configuration file.
 
-Example:
+### Examples
 
-    rf_service_validator -r https://192.168.1.100 -u USERNAME -p PASSWORD
+Using command-line arguments only (backward compatible):
+
+```bash
+python RedfishServiceValidator.py -r https://RedfishIP -u USERNAME -p PASSWORD
+```
+
+Using a configuration file:
+
+```bash
+# Uses config.ini from current directory
+python RedfishServiceValidator.py
+```
+
+Using a custom configuration file:
+
+```bash
+python RedfishServiceValidator.py --config myconfig.ini
+```
+
+Mixing configuration file and command-line arguments (command-line overrides config):
+
+```bash
+# Uses settings from config.ini but overrides the target host
+python RedfishServiceValidator.py --rhost https://192.168.1.200
+```
 
 ### Payload Option
 

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,62 @@
+# This file contains default configuration settings for the Redfish Service Validator
+# All settings can be overridden by command-line arguments
+
+[Authentication]
+# The username for authentication (required if not provided via command line)
+user = 
+
+# The password for authentication (required if not provided via command line)
+password = 
+
+# The authorization type (Basic or Session)
+authtype = Session
+
+[Connection]
+# The IP address (and port) of the Redfish service (required if not provided via command line)
+# Example: https://RedfishIP
+rhost = 
+
+# The timeout in seconds for HTTP requests (leave empty for no timeout)
+timeout = 
+
+[Proxy]
+# HTTP proxy for accessing external sites
+ext_http_proxy = 
+
+# HTTPS proxy for accessing external sites
+ext_https_proxy = 
+
+# HTTP proxy for accessing the Redfish service
+serv_http_proxy = 
+
+# HTTPS proxy for accessing the Redfish service
+serv_https_proxy = 
+
+[Paths]
+# Directory for generated report files
+logdir = logs
+
+# Directory for local schema files
+schema_directory = SchemaFiles
+
+# Directory containing mockups to override service responses (leave empty to disable)
+mockup = 
+
+[Validation]
+# Controls data model testing scope (leave empty to test entire service)
+# Format: payload_scope = Single or Tree
+# Format: payload_uri = /redfish/v1/Systems/1
+payload_scope = 
+payload_uri = 
+
+# Limit testing of collection members (format: RESOURCE1 COUNT1 RESOURCE2 COUNT2)
+collectionlimit = LogEntry 20
+
+# Skip OEM item validation (true/false)
+nooemcheck = false
+
+# Skip schema download and use cached schemas only (true/false)
+skipschema = false
+
+# Enable debug logging (true/false)
+debugging = false

--- a/redfish_service_validator/console_scripts.py
+++ b/redfish_service_validator/console_scripts.py
@@ -13,7 +13,9 @@ Brief : This file contains the definitions and functionalities for invoking
 
 import argparse
 import colorama
+import configparser
 import logging
+import os
 import redfish
 import sys
 from datetime import datetime
@@ -28,6 +30,115 @@ from redfish_service_validator import schema_pack
 tool_version = "3.1.6"
 
 
+def load_config(config_file):
+    """
+    Load configuration from a config.ini file
+
+    Args:
+        config_file: Path to the configuration file
+
+    Returns:
+        A dictionary containing the configuration values
+    """
+    config = configparser.ConfigParser()
+    config_values = {}
+
+    try:
+        if not os.path.isfile(config_file):
+            return config_values
+
+        config.read(config_file)
+
+        # Authentication section
+        if config.has_section('Authentication'):
+            if config.has_option('Authentication', 'user'):
+                user = config.get('Authentication', 'user').strip()
+                if user:
+                    config_values['user'] = user
+            if config.has_option('Authentication', 'password'):
+                password = config.get('Authentication', 'password').strip()
+                if password:
+                    config_values['password'] = password
+            if config.has_option('Authentication', 'authtype'):
+                authtype = config.get('Authentication', 'authtype').strip()
+                if authtype:
+                    config_values['authtype'] = authtype
+
+        # Connection section
+        if config.has_section('Connection'):
+            if config.has_option('Connection', 'rhost'):
+                rhost = config.get('Connection', 'rhost').strip()
+                if rhost:
+                    config_values['rhost'] = rhost
+            if config.has_option('Connection', 'timeout'):
+                timeout = config.get('Connection', 'timeout').strip()
+                if timeout:
+                    config_values['timeout'] = int(timeout)
+
+        # Proxy section
+        if config.has_section('Proxy'):
+            if config.has_option('Proxy', 'ext_http_proxy'):
+                ext_http_proxy = config.get('Proxy', 'ext_http_proxy').strip()
+                if ext_http_proxy:
+                    config_values['ext_http_proxy'] = ext_http_proxy
+            if config.has_option('Proxy', 'ext_https_proxy'):
+                ext_https_proxy = config.get('Proxy', 'ext_https_proxy').strip()
+                if ext_https_proxy:
+                    config_values['ext_https_proxy'] = ext_https_proxy
+            if config.has_option('Proxy', 'serv_http_proxy'):
+                serv_http_proxy = config.get('Proxy', 'serv_http_proxy').strip()
+                if serv_http_proxy:
+                    config_values['serv_http_proxy'] = serv_http_proxy
+            if config.has_option('Proxy', 'serv_https_proxy'):
+                serv_https_proxy = config.get('Proxy', 'serv_https_proxy').strip()
+                if serv_https_proxy:
+                    config_values['serv_https_proxy'] = serv_https_proxy
+
+        # Paths section
+        if config.has_section('Paths'):
+            if config.has_option('Paths', 'logdir'):
+                logdir = config.get('Paths', 'logdir').strip()
+                if logdir:
+                    config_values['logdir'] = logdir
+            if config.has_option('Paths', 'schema_directory'):
+                schema_directory = config.get('Paths', 'schema_directory').strip()
+                if schema_directory:
+                    config_values['schema_directory'] = schema_directory
+            if config.has_option('Paths', 'mockup'):
+                mockup = config.get('Paths', 'mockup').strip()
+                if mockup:
+                    config_values['mockup'] = mockup
+
+        # Validation section
+        if config.has_section('Validation'):
+            # Handle payload (scope and uri)
+            if config.has_option('Validation', 'payload_scope') and config.has_option('Validation', 'payload_uri'):
+                payload_scope = config.get('Validation', 'payload_scope').strip()
+                payload_uri = config.get('Validation', 'payload_uri').strip()
+                if payload_scope and payload_uri:
+                    config_values['payload'] = [payload_scope, payload_uri]
+
+            # Handle collection limit
+            if config.has_option('Validation', 'collectionlimit'):
+                collectionlimit = config.get('Validation', 'collectionlimit').strip()
+                if collectionlimit:
+                    config_values['collectionlimit'] = collectionlimit.split()
+
+            # Boolean flags
+            if config.has_option('Validation', 'nooemcheck'):
+                config_values['nooemcheck'] = config.getboolean('Validation', 'nooemcheck')
+            if config.has_option('Validation', 'skipschema'):
+                config_values['skipschema'] = config.getboolean('Validation', 'skipschema')
+            if config.has_option('Validation', 'debugging'):
+                config_values['debugging'] = config.getboolean('Validation', 'debugging')
+
+    except Exception as err:
+        print("WARNING: Error reading config file {}: {}".format(config_file, err))
+        return {}
+
+    return config_values
+
+
 def main():
     """
     Entry point for the service validator
@@ -36,14 +147,17 @@ def main():
     # Get the input arguments
     argget = argparse.ArgumentParser(description="Validate Redfish services against schemas")
     argget.add_argument(
-        "--user", "-u", "-user", "--username", type=str, required=True, help="The username for authentication"
-    )
-    argget.add_argument("--password", "-p", type=str, required=True, help="The password for authentication")
-    argget.add_argument(
-        "--rhost", "-r", "--ip", "-i", type=str, required=True, help="The address of the Redfish service (with scheme)"
+        "--config", "-c", type=str, default="config.ini", help="Path to configuration file; default: 'config.ini'"
     )
     argget.add_argument(
-        "--authtype", type=str, default="Session", choices=["Basic", "Session"], help="The authorization type"
+        "--user", "-u", "-user", "--username", type=str, help="The username for authentication"
+    )
+    argget.add_argument("--password", "-p", type=str, help="The password for authentication")
+    argget.add_argument(
+        "--rhost", "-r", "--ip", "-i", type=str, help="The address of the Redfish service (with scheme)"
+    )
+    argget.add_argument(
+        "--authtype", type=str, choices=["Basic", "Session"], help="The authorization type"
     )
     argget.add_argument("--ext_http_proxy", type=str, help="The URL of the HTTP proxy for accessing external sites")
     argget.add_argument("--ext_https_proxy", type=str, help="The URL of the HTTPS proxy for accessing external sites")
@@ -57,13 +171,11 @@ def main():
         "--logdir",
         "--report-dir",
         type=str,
-        default="logs",
         help="The directory for generated report files; default: 'logs'",
     )
     argget.add_argument(
         "--schema_directory",
         type=str,
-        default="SchemaFiles",
         help="Directory for local schema files; default: 'SchemaFiles'",
     )
     argget.add_argument(
@@ -78,7 +190,6 @@ def main():
     argget.add_argument(
         "--collectionlimit",
         type=str,
-        default=["LogEntry", "20"],
         help="Applies a limit to testing resources in collections; format: RESOURCE1 COUNT1 RESOURCE2 COUNT2 ...",
         nargs="+",
     )
@@ -99,7 +210,64 @@ def main():
         action="store_true",
         help="Controls the verbosity of the debugging output; if not specified only INFO and higher are logged",
     )
+
+    # Parse command-line arguments
     args = argget.parse_args()
+
+    # Load configuration from file
+    config_values = load_config(args.config)
+
+    # Required arguments: rhost, user, password
+    if args.rhost is None:
+        args.rhost = config_values.get('rhost')
+    if args.user is None:
+        args.user = config_values.get('user')
+    if args.password is None:
+        args.password = config_values.get('password')
+
+    # Check if required arguments are present
+    if args.rhost is None:
+        print("ERROR: Redfish service host is required (provide via --rhost or config file)")
+        sys.exit(1)
+    if args.user is None:
+        print("ERROR: Username is required (provide via --user or config file)")
+        sys.exit(1)
+    if args.password is None:
+        print("ERROR: Password is required (provide via --password or config file)")
+        sys.exit(1)
+
+    # Optional string arguments
+    if args.authtype is None:
+        args.authtype = config_values.get('authtype', 'Session')
+    if args.logdir is None:
+        args.logdir = config_values.get('logdir', 'logs')
+    if args.schema_directory is None:
+        args.schema_directory = config_values.get('schema_directory', 'SchemaFiles')
+    if args.mockup is None:
+        args.mockup = config_values.get('mockup')
+    if args.timeout is None:
+        args.timeout = config_values.get('timeout')
+    if args.ext_http_proxy is None:
+        args.ext_http_proxy = config_values.get('ext_http_proxy')
+    if args.ext_https_proxy is None:
+        args.ext_https_proxy = config_values.get('ext_https_proxy')
+    if args.serv_http_proxy is None:
+        args.serv_http_proxy = config_values.get('serv_http_proxy')
+    if args.serv_https_proxy is None:
+        args.serv_https_proxy = config_values.get('serv_https_proxy')
+    if args.payload is None:
+        args.payload = config_values.get('payload')
+    if args.collectionlimit is None:
+        args.collectionlimit = config_values.get('collectionlimit', ['LogEntry', '20'])
+
+    # Optional Boolean arguments
+    if not args.nooemcheck and 'nooemcheck' in config_values:
+        args.nooemcheck = config_values['nooemcheck']
+    if not args.skipschema and 'skipschema' in config_values:
+        args.skipschema = config_values['skipschema']
+    if not args.debugging and 'debugging' in config_values:
+        args.debugging = config_values['debugging']
+
     code, file = run_validator(vars(args))
     if code != 0:
         sys.exit(code)


### PR DESCRIPTION
This commit introduces config.ini support to the Redfish Service Validator, allowing users to configure tool settings via a configuration file in addition to command-line arguments.

Key features:
- Added config.ini template file with all configurable settings
- New --config/-c option to specify custom configuration file path
- Configuration sections: Authentication, Connection, Proxy, Paths, and Validation
- Settings precedence: Command-line > Config file > Defaults
- Made --user, --password, and --rhost optional when provided in config
- Full backward compatibility with existing command-line usage

Benefits:
- Simplified repeated operations with consistent settings
- Better user experience with reduced command-line verbosity
- Flexible configuration mixing (config file + CLI overrides)

Updated documentation with configuration file usage examples and comprehensive command-line reference.